### PR TITLE
quarter can return year+quarter. Minor documentation fix.

### DIFF
--- a/R/accessors-quarter.r
+++ b/R/accessors-quarter.r
@@ -11,13 +11,17 @@ NULL
 #' @param x a date-time object of class POSIXct, POSIXlt, Date, chron, yearmon, yearqtr, zoo, 
 #' zooreg, timeDate, xts, its, ti, jul, timeSeries, fts or anything else that can be converted 
 #' with as.POSIXlt
+#' @param with_year logical indicating whether or not to include they quarter's year.
 #' @keywords utilities manip chron methods
 #' @return numeric the fiscal quarter that the date-time occurs in
 #' @examples
 #' x <- ymd(c("2012-03-26", "2012-05-04", "2012-09-23", "2012-12-31"))
+#' quarter(x)
 #' # 1 2 3 4
+#' quarter(x, with_year = TRUE)
+#' # 2012.1 2012.2 2012.3 2012.4
 #' @export
-quarter <- function(x) {
+quarter <- function(x, with_year = FALSE) {
   m <- month(x)
   quarters <- c("1" = 1, 
                 "2" = 1, 
@@ -31,5 +35,9 @@ quarter <- function(x) {
                 "10" = 4, 
                 "11" = 4, 
                 "12" = 4)
-  unname(quarters[m])
+  if (isTRUE(with_year)){
+    q <- unname(quarters[m])
+    y <- year(x)
+    as.numeric(paste0(y, ".", q))
+  } else unname(quarters[m])
 }


### PR DESCRIPTION
Not exactly sure if this is the right format, but added the argument `with_year` to `quarter`. 

If `with_year = TRUE` then `quarter will return not only the quarter but also the year. 

I also made a minor documentation fix for the examples.
