### PR TITLE
Changed update.Date because it fails with a strange error if there is a ...

### DIFF
--- a/R/update.r
+++ b/R/update.r
@@ -172,7 +172,7 @@ update.Date <- function(object, ...){
   
   new <- update(lt, ...)
   
-  if (sum(c(new$hour, new$min, new$sec))) {
+  if (sum(c(new$hour, new$min, new$sec), na.rm = TRUE)) {
     new
   } else {
     as.Date(new)


### PR DESCRIPTION
I changed this line because it was failing with a strange error if there was a NA in the date and it was in `Date` format. Perhaps it would be nice to issue a warning.
