### PR TITLE
Remove match.call() access to as.period() unit argument

### DIFF
--- a/R/coercion.r
+++ b/R/coercion.r
@@ -395,12 +395,11 @@ setMethod("as.period", signature(x = "Interval"), function(x, unit = NULL, ...) 
   negs <- int_length(x) < 0 & !is.na(int_length(x))
   x[negs] <- int_flip(x[negs])
 
-  if (is.null(match.call()$unit)) {
+  if (is.null(unit)) {
     pers <- .int_to_period(x)
     pers[negs] <- -1 * pers[negs]
     return(pers)
   } else {
-    unit <- match.call()$unit
     unit <- standardise_period_names(unit)
     per <- get(paste(unit, "s", sep = ""))
     num <- x %/% per(1)


### PR DESCRIPTION
The `unit` argument inside the `Interval` method for `as.period()` is accessed via `match.call()$unit`.
This makes it impossible to use inside another function, as `match.call()$unit` returns the symbol instead of the value. 

For example, the following code throws an error as the `unit` argument inside `as.period()` is seen as a `myunit` symbol instead of a `"month"` character string :

```
f <- function(interval, myunit) {
  as.period(interval, unit=myunit)
}

interv <- new_interval(as.Date("2000-01-01"), today())
f(interv, myunit="month")
```
