### PR TITLE
Fix tests when run under non English locales:

### DIFF
--- a/R/accessors-month.r
+++ b/R/accessors-month.r
@@ -78,7 +78,7 @@ setMethod("month<-", signature("Period"), function(x, value){
 #' @param x a date-time object
 #' @return An integer of the number of days in the month component of the date-time object.
 days_in_month <- function(x) {
-  month_x <- month(x, label = TRUE)
+  month_x <- month(x, label = TRUE, locale = "C")
   n_days <- N_DAYS_IN_MONTHS[month_x]
   n_days[month_x == "Feb" & leap_year(x)] <- 29L
   n_days

--- a/man/hms.Rd
+++ b/man/hms.Rd
@@ -30,7 +30,7 @@ Transforms a character or numeric vector into a period object with the
 specified number of hours, minutes, and seconds. hms() recognizes all
 non-numeric characters except '-' as separators ('-' is used for negative
 durations).  After hours, minutes and seconds have been parsed, the
-remaining input is ingored.
+remaining input is ignored.
 }
 \examples{
 ms(c("09:10", "09:02", "1:10"))

--- a/tests/testthat/test-accessors.R
+++ b/tests/testthat/test-accessors.R
@@ -75,8 +75,8 @@ test_that("wday works with various start values", {
   expect_equal(as.character(wday(days, label = T, week_start = 1)),
                as.character(wday(days, label = T, week_start = 7)))
 
-  expect_equal(as.character(wday(days, label = T))[1], "Sat")
-  expect_equal(as.character(wday(days, label = T, abbr = FALSE))[1], "Saturday")
+  expect_equal(as.character(wday(days, label = T, locale = "C"))[1], "Sat")
+  expect_equal(as.character(wday(days, label = T, abbr = FALSE, locale = "C"))[1], "Saturday")
 
   expect_equal(wday(days, label = F, week_start = 1),
                c(6, 7, 6, 1, 7, 1, 2, 7, 1, 2, 3, 4, 4, 5, 6))
@@ -195,8 +195,8 @@ test_that("months accessor extracts correct month",{
   expect_that(month(posct), equals(2))
   expect_that(month(date), equals(2))
 
-  expect_that(as.character(month(date, label = TRUE)), equals("Feb"))
-  expect_that(as.character(month(date, label = TRUE, abbr = FALSE)),
+  expect_that(as.character(month(date, label = TRUE, locale = "C")), equals("Feb"))
+  expect_that(as.character(month(date, label = TRUE, abbr = FALSE, locale = "C")),
               equals("February"))
 
 })


### PR DESCRIPTION
The testsuite was failing on a computer with a non-English default locale. This PR fixes the tests so they work well under any locale.

- days_in_month: As N_DAYS_IN_MONTHS has English month names, month() needs to be called with an English locale (the "C" locale is English and always available)

- wday test: The wday in the test is compared with the English week day, so needs to be in English

- "month accessor extracts correct month": Comparison with English month names, needs C locale as well