### PR TITLE
trunc_multi_unit 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ Version 1.6.0.9000
 
 ### NEW FEATURES
 
+* Reduced memory footprint on `trunc_multi_unit` so that it overwrites the vector argument `x` versus making a new vector `y`.
 * [#438](https://github.com/tidyverse/lubridate/issues/438) New function `force_tzs` for "enforcement" of heterogeneous time zones.
 * [#438](https://github.com/tidyverse/lubridate/issues/438) New function `local_time` for the retrieval of local day time in different time zones.
 * [#560](https://github.com/tidyverse/lubridate/issues/560) New argument `cutoff_2000` for parsing functions to indicate 20th century cutoff for `y` format.

--- a/R/round.r
+++ b/R/round.r
@@ -289,29 +289,29 @@ ceiling_date <- function(x, unit = "seconds", change_on_boundary = NULL, week_st
 }
 
 trunc_multi_unit <- function(x, unit, n) {
-  y <- as.POSIXlt(x)
+  x <- as.POSIXlt(x)
   switch(unit,
          second = {
-           y$sec <- if (n == 1) trunc(y$sec) else floor_multi_unit(y$sec, n)
+           x$sec <- if (n == 1) trunc(x$sec) else floor_multi_unit(x$sec, n)
          },
          minute = {
-           y$sec[] <- 0
-           y$min <- floor_multi_unit(y$min, n)
+           x$sec[] <- 0
+           x$min <- floor_multi_unit(x$min, n)
          },
          hour = {
-           y$sec[] <- 0
-           y$min[] <- 0L
-           y$hour <- floor_multi_unit(y$hour, n)
+           x$sec[] <- 0
+           x$min[] <- 0L
+           x$hour <- floor_multi_unit(x$hour, n)
          },
          day = {
-           y$sec[] <- 0
-           y$min[] <- 0L
-           y$hour[] <- 0L
-           y$isdst[] <- -1L
-           y$mday <- floor_multi_unit1(y$mday, n)
+           x$sec[] <- 0
+           x$min[] <- 0L
+           x$hour[] <- 0L
+           x$isdst[] <- -1L
+           x$mday <- floor_multi_unit1(x$mday, n)
          },
          stop("Invalid unit ", unit))
-  y
+  x
 }
 
 floor_multi_unit <- function(x, n) {


### PR DESCRIPTION
Changed `y <- as.POSIXlt(x)` to `x <- as.POSIXlt(x)` to reduced the memory footprint of `trunc_multi_unit` and overwrite `x` rather than creating a new vector `y`.  Not a large change, but can be useful when `x` is a very long vector (currently using 1b records).

