### PR TITLE
Correctly sets TZDIR env (#575)

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -19,7 +19,7 @@
         else NULL
       }
     if (!is.null(tzdir)) {
-      Sys.setenv("TZDIR", tzdir)
+      Sys.setenv(TZDIR = tzdir)
     }
   }
 }


### PR DESCRIPTION
Hi, 

the fix a55725c1 for #575 has a small error that prevent the installation of lubridate. 
```r
Error: package or namespace load failed for 'lubridate':
 .onAttach failed in attachNamespace() for 'lubridate', details:
  call: Sys.setenv("TZDIR", tzdir)
  error: all arguments must be named
Erreur : le chargement a échoué
```
this PR changes this.


