### PR TITLE
Avoid partial match warning on update in round_ceiling when rounding to month

### DIFF
--- a/R/round.r
+++ b/R/round.r
@@ -281,7 +281,7 @@ ceiling_date <- function(x, unit = "seconds", change_on_boundary = NULL, week_st
                   minute = update(new, minute = ceil_multi_unit(minute(new), n), second = 0, simple = T),
                   hour   = update(new, hour = ceil_multi_unit(hour(new), n), minute = 0, second = 0, simple = T),
                   week   = update(new, wday = 8, hour = 0, minute = 0, second = 0, week_start = week_start),
-                  month  = update(new, month = new_month, mdays = 1, hours = 0, minutes = 0, seconds = 0),
+                  month  = update(new, months = new_month, mdays = 1, hours = 0, minutes = 0, seconds = 0),
                   year   = update(new, year = ceil_multi_unit(year(new), n), month = 1, mday = 1,  hour = 0, minute = 0, second = 0))
 
     reclass_date_maybe(new, x, unit)


### PR DESCRIPTION
In `round_ceiling` when rounding to month, there is a partial match of `month` to `months` in the `update` call: 

``` r
library(lubridate)
#> 
#> Attaching package: 'lubridate'
#> The following object is masked from 'package:base':
#> 
#>     date
options(warnPartialMatchArgs = TRUE)
x <- as.POSIXct(c("2009-08-03 12:01:59.23", "2010-08-03 12:01:59.23"), tz = "UTC")
ceiling_date(x, "month")
#> Warning in (function (object, years = integer(), months = integer(), days =
#> integer(), : partial argument match of 'month' to 'months'
#> [1] "2009-09-01 UTC" "2010-09-01 UTC"
```