### PR TITLE
Fix system timezone memoization.

### DIFF
--- a/src/update.cpp
+++ b/src/update.cpp
@@ -95,7 +95,7 @@ const char* get_system_tz() {
 
 const char* local_tz() {
   // initialize once per session
-  static const char* SYS_TZ = get_system_tz();
+  static const char* SYS_TZ = strdup(get_system_tz());
   const char* tz_env = std::getenv("TZ");
   if (tz_env == NULL) {
     return SYS_TZ;


### PR DESCRIPTION
The result of `get_system_tz` comes from a `STRING_ELT`, which seems to be automatically garbage collected, causing the static character pointer to point to an invalid location. Duplicating the string is a small leak, but prevents this invalid access.

Alternatively, you could not do the memoization; I'm not sure what the benefit or downside of that is.

This should fix several of the [failures on CRAN](https://cran.r-project.org/web/checks/check_results_lubridate.html).