### PR TITLE
Remove extraneous include.

### DIFF
--- a/src/update.cpp
+++ b/src/update.cpp
@@ -3,7 +3,6 @@
 #include <unordered_map>
 #include "civil_time.h"
 #include "time_zone.h"
-#include "time_zone_if.h"
 #include "utils.h"
 #include <Rcpp.h>
 


### PR DESCRIPTION
Nothing from it is used, plus it's an "internal" cctz file so dropping
the include allows building against an unbundled system cctz.