### PR TITLE
Remove unneeded commas from DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,9 +30,9 @@ Depends:
     R (>= 3.0.0)
 Imports:
     stringr,
-    Rcpp (>= 0.12.13),
+    Rcpp (>= 0.12.13)
 LinkingTo:
-    Rcpp,
+    Rcpp
 Suggests:
     testthat,
     knitr,


### PR DESCRIPTION
The DESCRIPTION file contains two unneeded commas in `Imports` and `LinkingTo`.