### PR TITLE
Add Compare method for duration and numeric objects.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ Version 1.7.4.9000
 
 ### NEW FEATURES
 
+* [#695](https://github.com/tidyverse/lubridate/issues/695) Durations can now be compared with numeric vectors. 
 * [#681](https://github.com/tidyverse/lubridate/issues/681) New constants `NA_Date_` and `NA_POSIXct_` which parallel built-in primitive constants.
 * [#681](https://github.com/tidyverse/lubridate/issues/681) New constructors `Date()` and `POSIXct()` which parallel built-in primitive constructors.
 

--- a/R/durations.r
+++ b/R/durations.r
@@ -352,13 +352,13 @@ setMethod("Compare", c(e1 = "ANY", e2 = "Duration"),
 #' @export
 setMethod("Compare", signature(e1 = "Duration", e2 = "numeric"),
           function(e1, e2) {
-            callGeneric(e1, as.duration(e2))
+            callGeneric(e1@.Data, e2)
           })
 
 #' @export
 setMethod("Compare", signature(e1 = "numeric", e2 = "Duration"),
           function(e1, e2) {
-            callGeneric(as.duration(e1), e2)
+            callGeneric(e1, e2@.Data)
           })
 
 #' @export

--- a/R/durations.r
+++ b/R/durations.r
@@ -349,6 +349,18 @@ setMethod("Compare", c(e1 = "ANY", e2 = "Duration"),
           })
 
 #' @export
+setMethod("Compare", signature(e1 = "Duration", e2 = "numeric"),
+          function(e1, e2) {
+            callGeneric(e1, as.duration(e2))
+          })
+
+#' @export
+setMethod("Compare", signature(e1 = "numeric", e2 = "Duration"),
+          function(e1, e2) {
+            callGeneric(as.duration(e1), e2)
+          })
+
+#' @export
 setMethod("Compare", signature(e1 = "Duration", e2 = "character"),
           function(e1, e2) {
             callGeneric(e1, as.duration(e2))
@@ -365,7 +377,6 @@ setMethod("Compare", c(e1 = "difftime", e2 = "Duration"),
           function(e1, e2) {
             callGeneric(as.numeric(e1, "secs"), e2@.Data)
           })
-
 
 #' @export
 setMethod("Compare", c(e1 = "Duration", e2 = "difftime"),

--- a/R/durations.r
+++ b/R/durations.r
@@ -37,6 +37,7 @@ setClass("Duration", contains = c("Timespan", "numeric"), validity = check_durat
 #'   Compare,difftime,Duration-method Compare,ANY,Duration-method
 #'   Compare,Duration,Period-method Compare,Duration,difftime-method
 #'   Compare,character,Duration-method Compare,Duration,character-method
+#'   Compare,numeric,Duration-method Compare,Duration,numeric-method
 #'   as.numeric,Duration-method show,Duration-method c,Duration-method
 #'   rep,Duration-method [,Duration-method [<-,Duration,ANY,ANY,ANY-method
 #'   [[,Duration-method [[<-,Duration,ANY,ANY,ANY-method $,Duration-method

--- a/man/hidden_aliases.Rd
+++ b/man/hidden_aliases.Rd
@@ -80,6 +80,8 @@
 \alias{Compare,Duration,difftime-method}
 \alias{Compare,character,Duration-method}
 \alias{Compare,Duration,character-method}
+\alias{Compare,numeric,Duration-method}
+\alias{Compare,Duration,numeric-method}
 \alias{as.numeric,Duration-method}
 \alias{show,Duration-method}
 \alias{c,Duration-method}

--- a/tests/testthat/test-durations.R
+++ b/tests/testthat/test-durations.R
@@ -39,7 +39,6 @@ test_that("sub-unit fractional parsing works as expected", {
 
   expect_identical(duration(".1min .3sec .3secs .0H .2M .5d"),
                    duration(seconds = 6.6, minutes = .2, hours = 12))
-
 })
 
 test_that("parsing with 0 units works as expected", {
@@ -48,8 +47,6 @@ test_that("parsing with 0 units works as expected", {
   expect_equal(period("2d 0H 0M 1s"), days(2) + seconds(1))
   expect_equal(period("y 0m 2d 0H 0M 1s"), years(1) + days(2) + seconds(1))
 })
-
-
 
 test_that("make_difftime handles vectors", {
   x <- as.POSIXct(c("2008-08-03 13:01:59", "2008-08-03 13:01:59"), tz = "UTC")
@@ -70,7 +67,6 @@ test_that("make_difftime handles vectors", {
 
 })
 
-
 test_that("duration works as expected", {
   dur <- duration(seconds = 5, minutes = 30, days = 0,
     hour = 1, weeks = 2)
@@ -78,7 +74,6 @@ test_that("duration works as expected", {
   expect_equal(dur@.Data, 1215005)
   expect_is(dur, "Duration")
 })
-
 
 test_that("duration handles vectors", {
   dur1 <- duration(seconds = c(5, 1), minutes = c(30, 0),
@@ -92,8 +87,6 @@ test_that("duration handles vectors", {
   expect_is(dur2, "Duration")
 
 })
-
-
 
 test_that("as.duration handles vectors", {
   expect_that(as.duration(minutes(1:3)), equals(dminutes(1:3)))
@@ -131,14 +124,12 @@ test_that("as.duration handles difftimes", {
   expect_is(dur, "Duration")
 })
 
-
 test_that("eobjects handle vectors", {
   dur <- dseconds(c(1, 3, 4))
 
   expect_equal(dur@.Data, c(1, 3, 4))
   expect_is(dur, "Duration")
 })
-
 
 test_that("is.duration works as expected", {
   ct_time <- as.POSIXct("2008-08-03 13:01:59", tz = "UTC")
@@ -169,7 +160,6 @@ test_that("format.Duration correctly displays durations with an NA", {
 
   expect_equivalent(format(dur), c("5s", NA))
 })
-
 
 test_that("summary.Duration creates useful summary", {
   dur <- dminutes(5)
@@ -217,7 +207,6 @@ test_that("as.duration handles NA objects", {
   expect_equal(as.duration(NA), na.dur)
 })
 
-
 test_that("Comparison operators work duration and difftime objects (#323)", {
   t1 <- now()
   t2 <- t1 + dhours(1)
@@ -230,6 +219,6 @@ test_that("Comparison operators work duration and difftime objects (#323)", {
   expect_true(dhours(1) > dminutes(59))
   expect_true(dhours(1) == dseconds(3600))
 
-  expect_error(dhours(1) == 3600)
-  expect_error(dhours(1) == 1)
+  expect_true(dhours(1) == 3600)
+  expect_false(dhours(1) == 1)
 })

--- a/tests/testthat/test-ops-compare.R
+++ b/tests/testthat/test-ops-compare.R
@@ -48,14 +48,22 @@ test_that("duration comparison with periods works as expected", {
   expect_true(duration("day 1S 2H 3m 2y") >  period(days = 1, months = 3, years = 2, hours = 2))
 })
 
-
-test_that("character comparison with durrations works as expected", {
+test_that("character comparison with durations works as expected", {
   expect_true("day" == duration(days = 1))
   expect_true("2 days, 2 secs" == duration(days = 2, seconds = 2))
   expect_true(duration("day 1s") >  duration(days = 1))
   expect_true("day 1s" >  duration(days = 1))
   expect_true("day 1S 2H" == duration(days = 1, seconds = 1, hours = 2))
   expect_false("day 1S 2H" < duration(days = 1, hours = 2))
+})
+
+test_that("numeric comparison with durations works as expected", {
+  expect_true(1 == duration(secs = 1))
+  expect_true(172802 == duration(days = 2, seconds = 2))
+  expect_true(86401 > duration(days = 1))
+  expect_true(93601 == duration(days = 1, seconds = 1, hours = 2))
+  expect_true(86400 < duration(days = 1, hours = 2))
+  expect_true(10 > as.duration(1))
 })
 
 test_that("difftime comparison with periods works", {


### PR DESCRIPTION
Closes #695. 

Let me know if you prefer to have the coercion go the other way, ie: 

```
setMethod("Compare", signature(e1 = "Duration", e2 = "numeric"),
         function(e1, e2) {
            callGeneric(as.numeric(e1, "secs"), e2)
          })
```

Also will fix tidyverse/ggplot2#2414
