### PR TITLE
Fix typo in period docs

### DIFF
--- a/R/periods.r
+++ b/R/periods.r
@@ -298,14 +298,10 @@ setMethod("$<-", signature(x = "Period"), function(x, name, value) {
 #' to and subtracted to date-times to create a user interface similar to object
 #' oriented programming.
 #'
-#' Note: Arithmetic with periods can results in undefined behavior when
-#' non-existent dates are involved (such as February 29th). Please see
-#' [Period-class] for more details and \code{\link{\%m+\%}} and
-#' [add_with_rollback()] for alternative operations. Note: Arithmetic with
-#' periods can results in undefined behavior when non-existent dates are
-#' involved (such as February 29th in non-leap years). Please see [Period-class]
-#' for more details and \code{\link{\%m+\%}} and [add_with_rollback()] for
-#' alternative operations.
+#' Note: Arithmetic with periods can result in undefined behavior when
+#' non-existent dates are involved (such as February 29th in non-leap years).
+#' Please see [Period-class] for more details and \code{\link{\%m+\%}} and
+#' [add_with_rollback()] for alternative operations.
 #'
 #' @name period
 #' @aliases periods


### PR DESCRIPTION
I noticed a repeated section in the docs for period. Here's a PR to fix it.