### PR TITLE
 replace dead link by document cited, use https

### DIFF
--- a/R/accessors-week.r
+++ b/R/accessors-week.r
@@ -14,8 +14,8 @@ NULL
 #' @return the weeks element of x as an integer number
 #' @keywords utilities manip chron
 #' @references
-#'    \url{http://en.wikipedia.org/wiki/ISO_week_date}
-#'    \url{http://www.cmmcp.org/epiweek.htm}
+#'    \url{https://en.wikipedia.org/wiki/ISO_week_date}
+#'    \url{https://www.cmmcp.org/sites/cmmcp/files/uploads/spring_skeeter_06.pdf}
 #' @seealso [isoyear()]
 #' @examples
 #' x <- ymd("2012-03-26")

--- a/R/accessors-year.r
+++ b/R/accessors-year.r
@@ -14,8 +14,8 @@ NULL
 #' @return the years element of x as a decimal number
 #' @keywords utilities manip chron methods
 #' @references
-#'    \url{http://en.wikipedia.org/wiki/ISO_week_date}
-#'    \url{http://www.cmmcp.org/epiweek.htm}
+#'    \url{https://en.wikipedia.org/wiki/ISO_week_date}
+#'    \url{https://www.cmmcp.org/sites/cmmcp/files/uploads/spring_skeeter_06.pdf}
 #' @examples
 #' x <- ymd("2012-03-26")
 #' year(x)


### PR DESCRIPTION
Previous epi week link was not resolving to an existing page.
The best replacement on the CMMCP website would probably be [this one](https://www.cmmcp.org/mosquito-surveillance-data/pages/epi-week-calendars-2008-2019), but we might as well cite the original paper referenced.
Just in case, I also archived the PDF on the Internet Archive's Wayback Machine: https://web.archive.org/web/20190724124018/https://www.cmmcp.org/sites/cmmcp/files/uploads/spring_skeeter_06.pdf