### PR TITLE
In `add_months()`, conditionally attempt to add months

### DIFF
--- a/R/ops-addition.r
+++ b/R/ops-addition.r
@@ -62,6 +62,10 @@ add_period_to_date <- function(per, date) {
 }
 
 add_months <- function(mt, mos) {
+  if (mos == 0L) {
+    return(mt)
+  }
+
   mt$mon <- mt$mon + mos
   ndays <- as.numeric(format.POSIXlt(mt, "%d", usetz = FALSE))
   mt$mon[mt$mday != ndays] <- NA

--- a/R/ops-addition.r
+++ b/R/ops-addition.r
@@ -62,7 +62,7 @@ add_period_to_date <- function(per, date) {
 }
 
 add_months <- function(mt, mos) {
-  if (mos == 0L) {
+  if (all(mos == 0L)) {
     return(mt)
   }
 


### PR DESCRIPTION
This is a small (but noticeable!) optimization to `add_months()`, and through it, the common case of `<date> + days()`.

```r
library(lubridate, warn.conflicts = FALSE)

x <- as.Date("2019-01-01") + 0:100000

# before
bench::mark(x + days(1), iterations = 100)
#> # A tibble: 1 x 6
#>   expression       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 x + days(1)    149ms    153ms      6.42      33MB     76.5

# after
bench::mark(x + days(1), iterations = 100)
#> # A tibble: 1 x 6
#>   expression       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 x + days(1)    109ms    113ms      8.74    23.8MB     28.5
```