### PR TITLE
Strip enhances

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,12 +59,8 @@ Suggests:
     testthat
 Enhances:
     chron,
-    fts,
     timeDate,
-    timeSeries,
     tis,
-    tseries,
-    xts,
     zoo
 LinkingTo:
     Rcpp


### PR DESCRIPTION
These packages are not used anywhere in lubridate, so I think it makes sense to drop them.

Fixes #821