### PR TITLE
addition works with infinite dates and timespans

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ Version 1.7.4.9000
 * [#778](https://github.com/tidyverse/lubridate/issues/778) `duration()` works with repeated units
 * [#682](https://github.com/tidyverse/lubridate/issues/682) Fix quarter extraction with small `fiscal_start`s.
 * [#703](https://github.com/tidyverse/lubridate/issues/703) `leap_year()` works with objects supported by `year()`.
+* [#732](https://github.com/tidyverse/lubridate/issues/732) addition works with infinite dates and timespans.
 
 
 Version 1.7.4

--- a/R/ops-addition.r
+++ b/R/ops-addition.r
@@ -17,11 +17,10 @@ add_duration_to_date <- function(dur, date) {
     date <- as.POSIXct(date)
     ans <- with_tz(date + dur@.Data, "UTC")
 
-    if (all(is.na(ans))) return(as.Date(ans))  # ALL NAs
-
-    if (all(hour(na.omit(ans)) == 0  &
-            minute(na.omit(ans)) == 0 &
-            second(na.omit(ans)) == 0)) {
+    if (all(is.na(ans) |
+            is.infinite(ans) |
+            is.nan(ans) |
+            (hour(ans) == 0 & minute(ans) == 0 & second(ans) == 0))) {
       return(as.Date(ans))
     }
 
@@ -58,7 +57,11 @@ add_period_to_date <- function(per, date) {
   if (is.Date(date) && sum(new$sec, new$min, new$hour, na.rm = TRUE) != 0)
     return(new)
 
-  reclass_date(new, date)
+  new <- reclass_date(new, date)
+  indices_infinity <- is.infinite(per) | is.infinite(as.numeric(date))
+  new[indices_infinity] <- as_date(as.numeric(per)[indices_infinity] +
+                                     as.numeric(date)[indices_infinity])
+  new
 }
 
 add_months <- function(mt, mos) {


### PR DESCRIPTION
Fixes #732 . Actually two bugs. For `add_duration_to_date` it had to be tackled that hour(infinity) etc. produces `NA`. For `add_period_to_date` the problem was that the date is tranformed to a POSIXlt for the mathematics, which is a class that does not account for infinity. The POSIXlt part is left as it was -- only after the answer is transformed back to the original date class there is a correction for infinite outcomes.