### PR TITLE
Update documentation as-date

### DIFF
--- a/R/coercion.r
+++ b/R/coercion.r
@@ -604,6 +604,7 @@ setMethod("as.character", signature(x = "Interval"), function(x, ...) {
 #'      a more intuitive conversion (see examples)
 #'   \item Both functions provide a default origin argument for numeric
 #'      vectors.
+#'   \item Both functions will generate NAs for invalid date format. A warning message will provide a count of the elements that were not converted
 #'   \item `as_datetime()` defaults to using UTC.
 #' }
 #'
@@ -626,6 +627,9 @@ setMethod("as.character", signature(x = "Interval"), function(x, ...) {
 #' c(as_date(dt_europe), as.Date(dt_europe))
 #' ## need not supply origin
 #' as_date(10)
+#' ## Will replace invalid date format with NA
+#' dt_wrong <- c("2009-09-29", "2012-11-29", "2015-29-12")
+#' as_date(dt_wrong)
 #' @export
 setGeneric(name = "as_date",
            def = function(x, ...) standardGeneric("as_date"))

--- a/man/as_date.Rd
+++ b/man/as_date.Rd
@@ -67,6 +67,7 @@ tweaks to make them work more intuitively.
 a more intuitive conversion (see examples)
 \item Both functions provide a default origin argument for numeric
 vectors.
+\item Both functions will generate NAs for invalid date format. A warning message will provide a count of the elements that were not converted
 \item \code{as_datetime()} defaults to using UTC.
 }
 }
@@ -78,4 +79,7 @@ c(as_date(dt_utc), as.Date(dt_utc))
 c(as_date(dt_europe), as.Date(dt_europe))
 ## need not supply origin
 as_date(10)
+## Will replace invalid date format with NA
+dt_wrong <- c("2009-09-29", "2012-11-29", "2015-29-12")
+as_date(dt_wrong)
 }


### PR DESCRIPTION
Fixed #839

The original request was tackling 2 problems
- There was no mention in the documentation of  NA generation by `as_date` and `as_datetime`
- Generate a warning for `make_date` and `make_datetime`, but I found the 2 functions were not consistent how they handle out of range value (see #855) => not implemented in this pull request
