### PR TITLE
rename check_ymd to check_mdays; remove unused argument

### DIFF
--- a/src/datetime.c
+++ b/src/datetime.c
@@ -118,7 +118,7 @@ SEXP C_make_dt(SEXP year, SEXP month, SEXP day, SEXP hour, SEXP minute, SEXP sec
 
 	  int is_leap = IS_LEAP(y);
 
-	  if(check_ymd(y, m, d, is_leap)){
+	  if(check_mdays(m, d, is_leap)){
 
 		SECS += d30;
 		y -= 2000;
@@ -185,7 +185,7 @@ SEXP C_make_d(SEXP year, SEXP month, SEXP day) {
 
 	  int is_leap = IS_LEAP(y);
 
-	  if(check_ymd(y, m, d, is_leap)){
+	  if(check_mdays(m, d, is_leap)){
 
 		SECS += d30;
 		y -= 2000;

--- a/src/utils.c
+++ b/src/utils.c
@@ -49,8 +49,8 @@ int adjust_leap_years(int y, int m, int is_leap){
   return SECS;
 }
 
-// check if y, m, d make sense
-int check_ymd(int y, int m, int d, int is_leap){
+// check if d makes sense in this month
+int check_mdays(int m, int d, int is_leap){
 
   int succeed = 1;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -47,7 +47,7 @@ typedef struct {
 #define SKIP_NON_DIGITS(X) while(*X && !(DIGIT(*X))) {(X)++;}
 
 int adjust_leap_years(int y, int m, int is_leap);
-int check_ymd(int y, int m, int d, int is_leap);
+int check_mdays(int m, int d, int is_leap);
 int parse_alphanum(const char **c, const char **strings, const int strings_len, const char ignore_case);
 double parse_fractional (const char **c);
 int parse_int (const char **c, const int N, const int strict);


### PR DESCRIPTION
This function actually checks if the day number is valid in a given month, so it's better named `check_mdays`. Also, there is one unused argument, which I've removed.