### PR TITLE
Fix tm_gmtoff build failure on AIX

### DIFF
--- a/src/cctz/src/time_zone_libc.cc
+++ b/src/cctz/src/time_zone_libc.cc
@@ -26,6 +26,12 @@
 #include "cctz/civil_time.h"
 #include "cctz/time_zone.h"
 
+#if defined(_AIX)
+extern "C" {
+  extern long altzone;
+}
+#endif
+
 namespace cctz {
 
 namespace {
@@ -40,7 +46,7 @@ auto tm_zone(const std::tm& tm) -> decltype(_tzname[0]) {
   const bool is_dst = tm.tm_isdst > 0;
   return _tzname[is_dst];
 }
-#elif defined(__sun)
+#elif defined(__sun) || defined(_AIX)
 // Uses the globals: 'timezone', 'altzone' and 'tzname'.
 auto tm_gmtoff(const std::tm& tm) -> decltype(timezone) {
   const bool is_dst = tm.tm_isdst > 0;


### PR DESCRIPTION
Port of 98fb541 from upstream cctz to fix builds on AIX, see
https://github.com/google/cctz/pull/177