### PR TITLE
[#928] Set TZDIR if empty

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,9 +8,6 @@
 
   ## adapted from Syz.timezone and OlsonNames function
   .find_tzdir <- function() {
-    ## Initialize Sys.timezone() cache to avoid resetting TZDIR at a later stage.
-    ## As of R4.0.3 Sys.timezone() intrusively sets TZDIR to non path values.
-    Sys.timezone()
     if (.Platform$OS.type == "windows")
       return(file.path(R.home("share"), "zoneinfo"))
     tzdirs <- c("/usr/share/zoneinfo",
@@ -27,14 +24,10 @@
     else NULL
   }
 
+  ## Initialize Sys.timezone() cache to avoid resetting TZDIR at a later stage.
+  ## As of R4.0.3 Sys.timezone() intrusively sets TZDIR to non path values.
+  Sys.timezone()
   tzdir <- Sys.getenv("TZDIR")
-
-  if(tzdir == "") {
-    ## As of R4.0.3 Sys.timezone() intrusively sets TZDIR to non path values.
-    Sys.timezone()
-    tzdir <- Sys.getenv("TZDIR")
-  }
-
   if (tzdir == "internal") {
     Sys.setenv(TZDIR = file.path(R.home("share"), "zoneinfo"))
   } else if (tzdir == "macOS") {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -28,6 +28,13 @@
   }
 
   tzdir <- Sys.getenv("TZDIR")
+
+  if(tzdir == "") {
+    ## As of R4.0.3 Sys.timezone() intrusively sets TZDIR to non path values.
+    Sys.timezone()
+    tzdir <- Sys.getenv("TZDIR")
+  }
+
   if (tzdir == "internal") {
     Sys.setenv(TZDIR = file.path(R.home("share"), "zoneinfo"))
   } else if (tzdir == "macOS") {


### PR DESCRIPTION
This commit fixes https://github.com/tidyverse/lubridate/issues/928 for me. 

I start R --vanilla and then:

```
❯ R --vanilla
R version 4.0.3 (2020-10-10) -- "Bunny-Wunnies Freak Out"
Platform: x86_64-apple-darwin19.6.0 (64-bit)

r$> Sys.getenv("TZDIR")
[1] ""

r$> lubridate::dmy_hm("1 Sep 2020 1:00pm", tz="Africa/Blantyre")
[1] "2020-09-01 13:00:00 CAT"

r$> Sys.getenv("TZDIR")
[1] "/usr/share/zoneinfo"
```

<details><summary>session_info</summary>
<p>


```
r$> devtools::session_info()
─ Session info ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 setting  value
 version  R version 4.0.3 (2020-10-10)
 os       macOS Catalina 10.15.7
 system   x86_64, darwin19.6.0
 ui       unknown
 language (EN)
 collate  en_US.UTF-8
 ctype    en_US.UTF-8
 tz       America/New_York
 date     2020-11-19

─ Packages ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 package     * version    date       lib source
 assertthat    0.2.1      2019-03-21 [1] RSPM (R 4.0.3)
 backports     1.2.0      2020-11-02 [1] RSPM (R 4.0.3)
 callr         3.5.1      2020-10-13 [1] RSPM (R 4.0.3)
 cli           2.1.0      2020-10-12 [1] RSPM (R 4.0.3)
 crayon        1.3.4      2017-09-16 [1] RSPM (R 4.0.3)
 desc          1.2.0      2018-05-01 [1] RSPM (R 4.0.3)
 devtools      2.3.2      2020-09-18 [1] CRAN (R 4.0.3)
 digest        0.6.27     2020-10-24 [1] RSPM (R 4.0.3)
 ellipsis      0.3.1      2020-05-15 [1] RSPM (R 4.0.3)
 fansi         0.4.1      2020-01-08 [1] RSPM (R 4.0.3)
 fs            1.5.0      2020-07-31 [1] RSPM (R 4.0.3)
 generics      0.1.0      2020-10-31 [1] RSPM (R 4.0.3)
 glue          1.4.2      2020-08-27 [1] RSPM (R 4.0.3)
 lubridate     1.7.9.9001 2020-11-19 [1] local
 magrittr      1.5        2014-11-22 [1] RSPM (R 4.0.3)
 memoise       1.1.0      2017-04-21 [1] CRAN (R 4.0.3)
 pkgbuild      1.1.0      2020-07-13 [1] RSPM (R 4.0.3)
 pkgload       1.1.0      2020-05-29 [1] RSPM (R 4.0.3)
 prettyunits   1.1.1      2020-01-24 [1] RSPM (R 4.0.3)
 processx      3.4.4      2020-09-03 [1] RSPM (R 4.0.3)
 ps            1.4.0      2020-10-07 [1] RSPM (R 4.0.3)
 R6            2.5.0      2020-10-28 [1] RSPM (R 4.0.3)
 Rcpp          1.0.5      2020-07-06 [1] RSPM (R 4.0.3)
 remotes       2.2.0      2020-07-21 [1] CRAN (R 4.0.3)
 rlang         0.4.8      2020-10-08 [1] RSPM (R 4.0.3)
 rprojroot     1.3-2      2018-01-03 [1] RSPM (R 4.0.3)
 sessioninfo   1.1.1      2018-11-05 [1] CRAN (R 4.0.3)
 testthat      3.0.0      2020-10-31 [1] RSPM (R 4.0.3)
 usethis       1.6.3      2020-09-17 [1] CRAN (R 4.0.3)
 withr         2.3.0      2020-09-22 [1] RSPM (R 4.0.3)

[1] /usr/local/lib/R/4.0/site-library
[2] /usr/local/Cellar/r/4.0.3/lib/R/library
```

</p>
</details>

