### PR TITLE
Refactors `quarter()` API to allow for quarter start- and end-dates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ Version 1.7.9.2.9000
 
 ### NEW FEATURES
 
+* [#955](https://github.com/tidyverse/lubridate/pull/955) Add `type` argument to `quarter()` for more control over the returned class
 * `fast_strptime()` and `parse_date_time2()` now accept multiple formats and apply them in turn
 
 ### BUG FIXES

--- a/R/accessors-quarter.r
+++ b/R/accessors-quarter.r
@@ -8,31 +8,56 @@ NULL
 #' @param x a date-time object of class POSIXct, POSIXlt, Date, chron, yearmon,
 #'   yearqtr, zoo, zooreg, timeDate, xts, its, ti, jul, timeSeries, fts or
 #'   anything else that can be converted with as.POSIXlt
-#' @param with_year logical indicating whether or not to include the quarter's
-#'   year.
-#' @param fiscal_start numeric indicating the starting month of a fiscal year
-#' @return numeric
+#' @param type the format to be returned for the quarter. Can be one one of
+#'   "quarter" (default) or "quarter_year", which will return the numeric quarter with or
+#'   without a prepended year, or "date_first" or "date_last", which return the
+#'   dates starting or ending each quarter.
+#' @param fiscal_start numeric indicating the starting month of a fiscal year.
+#' @param with_year logical indicating whether or not to include the quarter or
+#'   semester's year. Soft-deprecated; use the `type` parameter instead.
+#' @return numeric or a vector of class POSIXct if `type` argument is `date_first`
+#'   or `date_last`
 #' @examples
 #' x <- ymd(c("2012-03-26", "2012-05-04", "2012-09-23", "2012-12-31"))
 #' quarter(x)
-#' quarter(x, with_year = TRUE)
-#' quarter(x, with_year = TRUE, fiscal_start = 11)
+#' quarter(x, type = "quarter_year")
+#' quarter(x, type = "quarter_year", fiscal_start = 11)
+#' quarter(x, type = "date_first", fiscal_start = 11)
+#' quarter(x, type = "date_last", fiscal_start = 11)
 #' semester(x)
 #' semester(x, with_year = TRUE)
 #' @export
-quarter <- function(x, with_year = FALSE, fiscal_start = 1) {
+quarter <- function(x, type = "quarter", fiscal_start = 1, with_year = type == "quarter_year") {
   fs <- (fiscal_start - 1) %% 12
   shifted <- seq(fs, 11 + fs) %% 12 + 1
   m <- month(x)
   quarters <- rep(1:4, each = 3)
   s <- match(m, shifted)
   q <- quarters[s]
-  if (with_year) {
-    this_year <- if (fs != 0) (fs + 1):12
-    year(x) + (m %in% this_year) + q/10
-  } else {
-    q
-  }
+
+  ## Doing this to handle positional calls where previously `with_year` was the
+  ## second param, and also now to handle soft-deprecation of `with_year`.
+  if (type == TRUE | with_year == TRUE) type <- "quarter_year"
+
+  switch(type,
+    "quarter" = q,
+    "quarter_year" = {
+      first_quarter_month <- ifelse(fs != 0, fs + 1, 0)
+      year(x) - (m < first_quarter_month) + (q / 10)
+    },
+    "date_first" = ,
+    "date_last" = {
+      starting_months <- shifted[seq(1, length(shifted), 3)]
+      final_years <- year(x) - (starting_months[q] > m)
+      quarter_starting_dates <- make_date(year = final_years, month = starting_months[q], day = 1L)
+      if (type == 'date_first') {
+        quarter_starting_dates
+      } else if (type == 'date_last') {
+        add_with_rollback(quarter_starting_dates, months(3)) - days(1)
+      }
+    },
+    stop("Unsuported type ", unit)
+  )
 }
 
 #' @rdname quarter

--- a/R/accessors-quarter.r
+++ b/R/accessors-quarter.r
@@ -42,8 +42,8 @@ quarter <- function(x, type = "quarter", fiscal_start = 1, with_year = type == "
   switch(type,
     "quarter" = q,
     "quarter_year" = {
-      first_quarter_month <- ifelse(fs != 0, fs + 1, 0)
-      year(x) - (m < first_quarter_month) + (q / 10)
+      this_year <- if (fs != 0) (fs + 1):12
+      year(x) + (m %in% this_year) + (q / 10)
     },
     "date_first" = ,
     "date_last" = {

--- a/R/accessors-quarter.r
+++ b/R/accessors-quarter.r
@@ -56,7 +56,7 @@ quarter <- function(x, type = "quarter", fiscal_start = 1, with_year = type == "
         add_with_rollback(quarter_starting_dates, months(3)) - days(1)
       }
     },
-    stop("Unsuported type ", unit)
+    stop("Unsuported type ", type)
   )
 }
 

--- a/man/parse_date_time.Rd
+++ b/man/parse_date_time.Rd
@@ -98,9 +98,10 @@ present in the training set.}
 otherwise. For compatibility with \code{\link[base:strptime]{base::strptime()}} the default is \code{TRUE}
 for \code{fast_strptime()} and \code{FALSE} for \code{parse_date_time2()}.}
 
-\item{cutoff_2000}{integer. For \code{y} format,  two-digit numbers smaller or equal to
-\code{cutoff_2000} are parsed as 20th's century, 19th's otherwise. Available only
-for functions relying on \code{lubridate}s internal parser.}
+\item{cutoff_2000}{integer. For \code{y} format,  two-digit numbers smaller or equal
+to \code{cutoff_2000} are parsed as though starting with \code{20}, otherwise parsed
+as though starting with \code{19}. Available only for functions relying on
+\code{lubridate}s internal parser.}
 
 \item{format}{a vector of formats. If multiple formats supplied they are
 applied in turn till success. The formats should include all the

--- a/man/quarter.Rd
+++ b/man/quarter.Rd
@@ -9,7 +9,7 @@ quarter(
   x,
   type = "quarter",
   fiscal_start = 1,
-  with_year = type == "quarter_year"
+  with_year = identical(type, "year.quarter")
 )
 
 semester(x, with_year = FALSE)
@@ -20,18 +20,18 @@ yearqtr, zoo, zooreg, timeDate, xts, its, ti, jul, timeSeries, fts or
 anything else that can be converted with as.POSIXlt}
 
 \item{type}{the format to be returned for the quarter. Can be one one of
-"quarter" (default) or "quarter_year", which will return the numeric quarter with or
-without a prepended year, or "date_first" or "date_last", which return the
-dates starting or ending each quarter.}
+"quarter" - return numeric quarter (default), "year.quarter" return
+fractional numeric year.quarter, "date_first" or "date_last" which return
+the date at the quarter's start end end.}
 
 \item{fiscal_start}{numeric indicating the starting month of a fiscal year.}
 
 \item{with_year}{logical indicating whether or not to include the quarter or
-semester's year. Soft-deprecated; use the \code{type} parameter instead.}
+semester's year (deprecated; use the \code{type} parameter instead).}
 }
 \value{
-numeric or a vector of class POSIXct if \code{type} argument is \code{date_first}
-or \code{date_last}
+numeric or a vector of class POSIXct if \code{type} argument is
+\code{date_first} or \code{date_last}
 }
 \description{
 Quarters divide the year into fourths. Semesters divide the year into halfs.
@@ -39,8 +39,8 @@ Quarters divide the year into fourths. Semesters divide the year into halfs.
 \examples{
 x <- ymd(c("2012-03-26", "2012-05-04", "2012-09-23", "2012-12-31"))
 quarter(x)
-quarter(x, type = "quarter_year")
-quarter(x, type = "quarter_year", fiscal_start = 11)
+quarter(x, type = "year.quarter")
+quarter(x, type = "year.quarter", fiscal_start = 11)
 quarter(x, type = "date_first", fiscal_start = 11)
 quarter(x, type = "date_last", fiscal_start = 11)
 semester(x)

--- a/man/quarter.Rd
+++ b/man/quarter.Rd
@@ -5,7 +5,12 @@
 \alias{semester}
 \title{Get the fiscal quarter and semester of a date-time}
 \usage{
-quarter(x, with_year = FALSE, fiscal_start = 1)
+quarter(
+  x,
+  type = "quarter",
+  fiscal_start = 1,
+  with_year = type == "quarter_year"
+)
 
 semester(x, with_year = FALSE)
 }
@@ -14,13 +19,19 @@ semester(x, with_year = FALSE)
 yearqtr, zoo, zooreg, timeDate, xts, its, ti, jul, timeSeries, fts or
 anything else that can be converted with as.POSIXlt}
 
-\item{with_year}{logical indicating whether or not to include the quarter's
-year.}
+\item{type}{the format to be returned for the quarter. Can be one one of
+"quarter" (default) or "quarter_year", which will return the numeric quarter with or
+without a prepended year, or "date_first" or "date_last", which return the
+dates starting or ending each quarter.}
 
-\item{fiscal_start}{numeric indicating the starting month of a fiscal year}
+\item{fiscal_start}{numeric indicating the starting month of a fiscal year.}
+
+\item{with_year}{logical indicating whether or not to include the quarter or
+semester's year. Soft-deprecated; use the \code{type} parameter instead.}
 }
 \value{
-numeric
+numeric or a vector of class POSIXct if \code{type} argument is \code{date_first}
+or \code{date_last}
 }
 \description{
 Quarters divide the year into fourths. Semesters divide the year into halfs.
@@ -28,8 +39,10 @@ Quarters divide the year into fourths. Semesters divide the year into halfs.
 \examples{
 x <- ymd(c("2012-03-26", "2012-05-04", "2012-09-23", "2012-12-31"))
 quarter(x)
-quarter(x, with_year = TRUE)
-quarter(x, with_year = TRUE, fiscal_start = 11)
+quarter(x, type = "quarter_year")
+quarter(x, type = "quarter_year", fiscal_start = 11)
+quarter(x, type = "date_first", fiscal_start = 11)
+quarter(x, type = "date_last", fiscal_start = 11)
 semester(x)
 semester(x, with_year = TRUE)
 }

--- a/tests/testthat/test-accessors.R
+++ b/tests/testthat/test-accessors.R
@@ -233,14 +233,12 @@ test_that("quarters accessor extracts correct quarter", {
   expect_equal(quarter(posct, type = "quarter"), 4)
   expect_equal(quarter(posct, type = "quarter_year"), 2010.4)
   expect_equal(quarter(posct, type = "date_first"), ymd("2010-10-01"))
-  expect_equal(quarter(posct, type = "date_last"), ymd("2010-21-31"))
+  expect_equal(quarter(posct, type = "date_last"), ymd("2010-12-31"))
   expect_equal(quarter(posct, with_year = TRUE), 2010.4)
   expect_equal(quarter(posct, fiscal_start = 11), 1)
   expect_equal(quarter(posct, fiscal_start = -2), 1)
-  ## NOTE: Previously, the tests below looked for `2011.1`. But should they
-  ## actually begin with 2010 as that's the year during which the first quarter begins?
-  expect_equal(quarter(posct, type = "quarter_year", fiscal_start = -2), 2010.1)
-  expect_equal(quarter(posct, type = "quarter_year", fiscal_start = 11), 2010.1)
+  expect_equal(quarter(posct, type = "quarter_year", fiscal_start = -2), 2011.1)
+  expect_equal(quarter(posct, type = "quarter_year", fiscal_start = 11), 2011.1)
   expect_equal(quarter(posct, type = "date_first", fiscal_start = 11), ymd("2010-11-01"))
   expect_equal(quarter(posct, type = "date_last", fiscal_start = 11), ymd("2011-01-31"))
 
@@ -248,14 +246,12 @@ test_that("quarters accessor extracts correct quarter", {
   expect_equal(quarter(poslt, type = "quarter"), 4)
   expect_equal(quarter(poslt, type = "quarter_year"), 2010.4)
   expect_equal(quarter(poslt, type = "date_first"), ymd("2010-10-01"))
-  expect_equal(quarter(poslt, type = "date_last"), ymd("2010-21-31"))
+  expect_equal(quarter(poslt, type = "date_last"), ymd("2010-12-31"))
   expect_equal(quarter(poslt, with_year = TRUE), 2010.4)
   expect_equal(quarter(poslt, fiscal_start = 11), 1)
   expect_equal(quarter(poslt, fiscal_start = -2), 1)
-  ## NOTE: Previously, the tests below looked for `2011.1`. But should they
-  ## actually begin with 2010 as that's the year during which the first quarter begins?
-  expect_equal(quarter(poslt, type = "quarter_year", fiscal_start = -2), 2010.1)
-  expect_equal(quarter(poslt, type = "quarter_year", fiscal_start = 11), 2010.1)
+  expect_equal(quarter(poslt, type = "quarter_year", fiscal_start = -2), 2011.1)
+  expect_equal(quarter(poslt, type = "quarter_year", fiscal_start = 11), 2011.1)
   expect_equal(quarter(poslt, type = "date_first", fiscal_start = 11), ymd("2010-11-01"))
   expect_equal(quarter(poslt, type = "date_last", fiscal_start = 11), ymd("2011-01-31"))
 
@@ -263,46 +259,86 @@ test_that("quarters accessor extracts correct quarter", {
   expect_equal(quarter(date, type = "quarter"), 4)
   expect_equal(quarter(date, type = "quarter_year"), 2010.4)
   expect_equal(quarter(date, type = "date_first"), ymd("2010-10-01"))
-  expect_equal(quarter(date, type = "date_last"), ymd("2010-21-31"))
+  expect_equal(quarter(date, type = "date_last"), ymd("2010-12-31"))
   expect_equal(quarter(date, with_year = TRUE), 2010.4)
   expect_equal(quarter(date, fiscal_start = 11), 1)
   expect_equal(quarter(date, fiscal_start = -2), 1)
-  ## NOTE: Previously, the tests below looked for `2011.1`. But should they
-  ## actually begin with 2010 as that's the year during which the first quarter begins?
-  expect_equal(quarter(date, type = "quarter_year", fiscal_start = -2), 2010.1)
-  expect_equal(quarter(date, type = "quarter_year", fiscal_start = 11), 2010.1)
+  expect_equal(quarter(date, type = "quarter_year", fiscal_start = -2), 2011.1)
+  expect_equal(quarter(date, type = "quarter_year", fiscal_start = 11), 2011.1)
   expect_equal(quarter(date, type = "date_first", fiscal_start = 11), ymd("2010-11-01"))
   expect_equal(quarter(date, type = "date_last", fiscal_start = 11), ymd("2011-01-31"))
 
-  # TODO:
-  # rewrite tests below
-
   x <- ymd(c("2012-03-01", "2012-03-26", "2012-05-04", "2012-09-23", "2012-12-31"))
-  expect_equal(quarter(x, with_year = TRUE, fiscal_start = 4),
+  expect_equal(quarter(x, type = "quarter", fiscal_start = 4),
+               c(4, 4, 1, 2, 3))
+  expect_equal(quarter(x, type = "quarter", fiscal_start = 11),
+               c(2, 2, 3, 4, 1))
+  expect_equal(quarter(x, type = "quarter_year", fiscal_start = 4),
                c(2012.4, 2012.4, 2013.1, 2013.2, 2013.3))
-  expect_equal(quarter(x, with_year = TRUE, fiscal_start = 11),
+  expect_equal(quarter(x, type = "quarter_year", fiscal_start = 11),
                c(2012.2, 2012.2, 2012.3, 2012.4, 2013.1))
+  expect_equal(quarter(x, type = "date_first", fiscal_start = 4),
+               ymd(c("2012-01-01", "2012-01-01", "2012-04-01", "2012-07-01", "2012-10-01")))
+  expect_equal(quarter(x, type = "date_first", fiscal_start = 11),
+               ymd(c("2012-02-01", "2012-02-01", "2012-05-01", "2012-08-01", "2012-11-01")))
+  expect_equal(quarter(x, type = "date_last", fiscal_start = 4),
+               ymd(c("2012-03-31", "2012-03-31", "2012-06-30", "2012-09-30", "2012-12-31")))
+  expect_equal(quarter(x, type = "date_last", fiscal_start = 11),
+               ymd(c("2012-04-30", "2012-04-30", "2012-07-31", "2012-10-31", "2013-01-31")))
 
   x <- ymd("2010-01-01") + months(0:11)
-  expect_equal(quarter(x, with_year = TRUE, fiscal_start = 6),
+  expect_equal(quarter(x, type = "quarter_year", fiscal_start = 6),
                c(2010.3, 2010.3, 2010.4, 2010.4, 2010.4, 2011.1, 2011.1, 2011.1,
                  2011.2, 2011.2, 2011.2, 2011.3))
-  expect_equal(quarter(x, with_year = TRUE, fiscal_start = 6),
-               quarter(x, with_year = TRUE, fiscal_start = -6))
+  expect_equal(quarter(x, type = "quarter_year", fiscal_start = 6),
+               quarter(x, type = "quarter_year", fiscal_start = -6))
+  expect_equal(quarter(x, type = "date_first", fiscal_start = 6),
+               ymd(c("2009-12-01", "2009-12-01", "2010-03-01", "2010-03-01",
+                     "2010-03-01", "2010-06-01", "2010-06-01", "2010-06-01",
+                     "2010-09-01", "2010-09-01", "2010-09-01", "2010-12-01")))
+  expect_equal(quarter(x, type = "date_first", fiscal_start = 6),
+               quarter(x, type = "date_first", fiscal_start = -6))
+  expect_equal(quarter(x, type = "date_last", fiscal_start = 6),
+               ymd(c("2010-02-28", "2010-02-28", "2010-05-31", "2010-05-31",
+                     "2010-05-31", "2010-08-31", "2010-08-31", "2010-08-31",
+                     "2010-11-30", "2010-11-30", "2010-11-30", "2011-02-28")))
+  expect_equal(quarter(x, type = "date_last", fiscal_start = 6),
+               quarter(x, type = "date_last", fiscal_start = -6))
+
   x <- ymd("2010-01-01") + months(seq(0, 23, by = 3))
-  expect_equal(quarter(x, with_year = TRUE, fiscal_start = 10),
+  expect_equal(quarter(x, type = "quarter_year", fiscal_start = 10),
                c(2010.2, 2010.3, 2010.4, 2011.1, 2011.2, 2011.3, 2011.4, 2012.1))
-  expect_equal(quarter(x, with_year = TRUE, fiscal_start = -2),
-               quarter(x, with_year = TRUE, fiscal_start = 10))
+  expect_equal(quarter(x, type = "quarter_year", fiscal_start = -2),
+               quarter(x, type = "quarter_year", fiscal_start = 10))
+  expect_equal(quarter(x, type = "date_first", fiscal_start = 10),
+               ymd(c("2010-01-01", "2010-04-01", "2010-07-01", "2010-10-01",
+                 "2011-01-01", "2011-04-01", "2011-07-01", "2011-10-01")))
+  expect_equal(quarter(x, type = "date_first", fiscal_start = -2),
+               quarter(x, type = "date_first", fiscal_start = 10))
+  expect_equal(quarter(x, type = "date_last", fiscal_start = 10),
+               ymd(c("2010-03-31", "2010-06-30", "2010-09-30", "2010-12-31",
+                 "2011-03-31", "2011-06-30", "2011-09-30", "2011-12-31")))
+  expect_equal(quarter(x, type = "date_last", fiscal_start = -2),
+               quarter(x, type = "date_last", fiscal_start = 10))
 
   x <- ymd(c("2018-07-15", "2018-12-27", "2019-01-01",
              "2019-06-01", "2019-07-01", "2019-10-16",
              "2019-12-31", "2020-01-01", "2020-06-30",
              "2020-07-01", "2020-11-09", "2021-01-19",
              "2021-06-30", "2021-07-01"))
-  expect_equal(quarter(x, with_year = T, fiscal_start = 7),
+  expect_equal(quarter(x, type = "quarter_year", fiscal_start = 7),
                c(2019.1, 2019.2, 2019.3, 2019.4, 2020.1, 2020.2, 2020.2, 2020.3,
                  2020.4, 2021.1, 2021.2, 2021.3, 2021.4, 2022.1))
+  expect_equal(quarter(x, type = "date_first", fiscal_start = 7),
+               ymd(c("2018-07-01", "2018-10-01", "2019-01-01", "2019-04-01",
+                     "2019-07-01", "2019-10-01", "2019-10-01", "2020-01-01",
+                     "2020-04-01", "2020-07-01", "2020-10-01", "2021-01-01",
+                     "2021-04-01", "2021-07-01")))
+  expect_equal(quarter(x, type = "date_last", fiscal_start = 7),
+               ymd(c("2018-09-30", "2018-12-31", "2019-03-31", "2019-06-30",
+                     "2019-09-30", "2019-12-31", "2019-12-31", "2020-03-31",
+                     "2020-06-30", "2020-09-30", "2020-12-31", "2021-03-31",
+                     "2021-06-30", "2021-09-30")))
 })
 
 test_that("years accessor extracts correct year", {

--- a/tests/testthat/test-accessors.R
+++ b/tests/testthat/test-accessors.R
@@ -229,23 +229,53 @@ test_that("quarters accessor extracts correct quarter", {
   poslt <- as.POSIXlt(posct)
   date <- as.Date(poslt)
 
-  expect_equal(quarter(poslt), 4)
-  expect_equal(quarter(poslt, with_year = TRUE), 2010.4)
-  expect_equal(quarter(poslt, fiscal_start = 11), 1)
-  expect_equal(quarter(poslt, with_year = TRUE, fiscal_start = -2), 2011.1)
-  expect_equal(quarter(poslt, with_year = TRUE, fiscal_start = 11), 2011.1)
-
   expect_equal(quarter(posct), 4)
+  expect_equal(quarter(posct, type = "quarter"), 4)
+  expect_equal(quarter(posct, type = "quarter_year"), 2010.4)
+  expect_equal(quarter(posct, type = "date_first"), ymd("2010-10-01"))
+  expect_equal(quarter(posct, type = "date_last"), ymd("2010-21-31"))
   expect_equal(quarter(posct, with_year = TRUE), 2010.4)
   expect_equal(quarter(posct, fiscal_start = 11), 1)
-  expect_equal(quarter(posct, with_year = TRUE, fiscal_start = -2), 2011.1)
-  expect_equal(quarter(posct, with_year = TRUE, fiscal_start = 11), 2011.1)
+  expect_equal(quarter(posct, fiscal_start = -2), 1)
+  ## NOTE: Previously, the tests below looked for `2011.1`. But should they
+  ## actually begin with 2010 as that's the year during which the first quarter begins?
+  expect_equal(quarter(posct, type = "quarter_year", fiscal_start = -2), 2010.1)
+  expect_equal(quarter(posct, type = "quarter_year", fiscal_start = 11), 2010.1)
+  expect_equal(quarter(posct, type = "date_first", fiscal_start = 11), ymd("2010-11-01"))
+  expect_equal(quarter(posct, type = "date_last", fiscal_start = 11), ymd("2011-01-31"))
+
+  expect_equal(quarter(poslt), 4)
+  expect_equal(quarter(poslt, type = "quarter"), 4)
+  expect_equal(quarter(poslt, type = "quarter_year"), 2010.4)
+  expect_equal(quarter(poslt, type = "date_first"), ymd("2010-10-01"))
+  expect_equal(quarter(poslt, type = "date_last"), ymd("2010-21-31"))
+  expect_equal(quarter(poslt, with_year = TRUE), 2010.4)
+  expect_equal(quarter(poslt, fiscal_start = 11), 1)
+  expect_equal(quarter(poslt, fiscal_start = -2), 1)
+  ## NOTE: Previously, the tests below looked for `2011.1`. But should they
+  ## actually begin with 2010 as that's the year during which the first quarter begins?
+  expect_equal(quarter(poslt, type = "quarter_year", fiscal_start = -2), 2010.1)
+  expect_equal(quarter(poslt, type = "quarter_year", fiscal_start = 11), 2010.1)
+  expect_equal(quarter(poslt, type = "date_first", fiscal_start = 11), ymd("2010-11-01"))
+  expect_equal(quarter(poslt, type = "date_last", fiscal_start = 11), ymd("2011-01-31"))
 
   expect_equal(quarter(date), 4)
+  expect_equal(quarter(date, type = "quarter"), 4)
+  expect_equal(quarter(date, type = "quarter_year"), 2010.4)
+  expect_equal(quarter(date, type = "date_first"), ymd("2010-10-01"))
+  expect_equal(quarter(date, type = "date_last"), ymd("2010-21-31"))
   expect_equal(quarter(date, with_year = TRUE), 2010.4)
   expect_equal(quarter(date, fiscal_start = 11), 1)
-  expect_equal(quarter(date, with_year = TRUE, fiscal_start = -2), 2011.1)
-  expect_equal(quarter(date, with_year = TRUE, fiscal_start = 11), 2011.1)
+  expect_equal(quarter(date, fiscal_start = -2), 1)
+  ## NOTE: Previously, the tests below looked for `2011.1`. But should they
+  ## actually begin with 2010 as that's the year during which the first quarter begins?
+  expect_equal(quarter(date, type = "quarter_year", fiscal_start = -2), 2010.1)
+  expect_equal(quarter(date, type = "quarter_year", fiscal_start = 11), 2010.1)
+  expect_equal(quarter(date, type = "date_first", fiscal_start = 11), ymd("2010-11-01"))
+  expect_equal(quarter(date, type = "date_last", fiscal_start = 11), ymd("2011-01-31"))
+
+  # TODO:
+  # rewrite tests below
 
   x <- ymd(c("2012-03-01", "2012-03-26", "2012-05-04", "2012-09-23", "2012-12-31"))
   expect_equal(quarter(x, with_year = TRUE, fiscal_start = 4),

--- a/tests/testthat/test-accessors.R
+++ b/tests/testthat/test-accessors.R
@@ -231,51 +231,54 @@ test_that("quarters accessor extracts correct quarter", {
 
   expect_equal(quarter(posct), 4)
   expect_equal(quarter(posct, type = "quarter"), 4)
-  expect_equal(quarter(posct, type = "quarter_year"), 2010.4)
+  expect_equal(quarter(posct, type = "year.quarter"), 2010.4)
   expect_equal(quarter(posct, type = "date_first"), ymd("2010-10-01"))
   expect_equal(quarter(posct, type = "date_last"), ymd("2010-12-31"))
   expect_equal(quarter(posct, with_year = TRUE), 2010.4)
   expect_equal(quarter(posct, fiscal_start = 11), 1)
   expect_equal(quarter(posct, fiscal_start = -2), 1)
-  expect_equal(quarter(posct, type = "quarter_year", fiscal_start = -2), 2011.1)
-  expect_equal(quarter(posct, type = "quarter_year", fiscal_start = 11), 2011.1)
+  expect_equal(quarter(posct, type = "year.quarter", fiscal_start = -2), 2011.1)
+  expect_equal(quarter(posct, type = "year.quarter", fiscal_start = 11), 2011.1)
   expect_equal(quarter(posct, type = "date_first", fiscal_start = 11), ymd("2010-11-01"))
   expect_equal(quarter(posct, type = "date_last", fiscal_start = 11), ymd("2011-01-31"))
 
   expect_equal(quarter(poslt), 4)
   expect_equal(quarter(poslt, type = "quarter"), 4)
-  expect_equal(quarter(poslt, type = "quarter_year"), 2010.4)
+  expect_equal(quarter(poslt, type = "year.quarter"), 2010.4)
   expect_equal(quarter(poslt, type = "date_first"), ymd("2010-10-01"))
   expect_equal(quarter(poslt, type = "date_last"), ymd("2010-12-31"))
   expect_equal(quarter(poslt, with_year = TRUE), 2010.4)
   expect_equal(quarter(poslt, fiscal_start = 11), 1)
   expect_equal(quarter(poslt, fiscal_start = -2), 1)
-  expect_equal(quarter(poslt, type = "quarter_year", fiscal_start = -2), 2011.1)
-  expect_equal(quarter(poslt, type = "quarter_year", fiscal_start = 11), 2011.1)
+  expect_equal(quarter(poslt, type = "year.quarter", fiscal_start = -2), 2011.1)
+  expect_equal(quarter(poslt, type = "year.quarter", fiscal_start = 11), 2011.1)
   expect_equal(quarter(poslt, type = "date_first", fiscal_start = 11), ymd("2010-11-01"))
   expect_equal(quarter(poslt, type = "date_last", fiscal_start = 11), ymd("2011-01-31"))
 
   expect_equal(quarter(date), 4)
   expect_equal(quarter(date, type = "quarter"), 4)
-  expect_equal(quarter(date, type = "quarter_year"), 2010.4)
+  expect_equal(quarter(date, type = "year.quarter"), 2010.4)
   expect_equal(quarter(date, type = "date_first"), ymd("2010-10-01"))
   expect_equal(quarter(date, type = "date_last"), ymd("2010-12-31"))
   expect_equal(quarter(date, with_year = TRUE), 2010.4)
   expect_equal(quarter(date, fiscal_start = 11), 1)
   expect_equal(quarter(date, fiscal_start = -2), 1)
-  expect_equal(quarter(date, type = "quarter_year", fiscal_start = -2), 2011.1)
-  expect_equal(quarter(date, type = "quarter_year", fiscal_start = 11), 2011.1)
+  expect_equal(quarter(date, type = "year.quarter", fiscal_start = -2), 2011.1)
+  expect_equal(quarter(date, type = "year.quarter", fiscal_start = 11), 2011.1)
   expect_equal(quarter(date, type = "date_first", fiscal_start = 11), ymd("2010-11-01"))
   expect_equal(quarter(date, type = "date_last", fiscal_start = 11), ymd("2011-01-31"))
 
   x <- ymd(c("2012-03-01", "2012-03-26", "2012-05-04", "2012-09-23", "2012-12-31"))
+  expect_equal(quarter(x, FALSE, fiscal_start = 11), c(2, 2, 3, 4, 1))
+  expect_equal(quarter(x, fiscal_start = 11, FALSE), c(2, 2, 3, 4, 1))
+  expect_equal(quarter(x, TRUE, fiscal_start = 9), c(2012.3, 2012.3, 2012.3, 2013.1, 2013.2))
+  expect_equal(quarter(x, TRUE, fiscal_start = 9), c(2012.3, 2012.3, 2012.3, 2013.1, 2013.2))
+
   expect_equal(quarter(x, type = "quarter", fiscal_start = 4),
                c(4, 4, 1, 2, 3))
-  expect_equal(quarter(x, type = "quarter", fiscal_start = 11),
-               c(2, 2, 3, 4, 1))
-  expect_equal(quarter(x, type = "quarter_year", fiscal_start = 4),
+  expect_equal(quarter(x, type = "year.quarter", fiscal_start = 4),
                c(2012.4, 2012.4, 2013.1, 2013.2, 2013.3))
-  expect_equal(quarter(x, type = "quarter_year", fiscal_start = 11),
+  expect_equal(quarter(x, type = "year.quarter", fiscal_start = 11),
                c(2012.2, 2012.2, 2012.3, 2012.4, 2013.1))
   expect_equal(quarter(x, type = "date_first", fiscal_start = 4),
                ymd(c("2012-01-01", "2012-01-01", "2012-04-01", "2012-07-01", "2012-10-01")))
@@ -287,11 +290,11 @@ test_that("quarters accessor extracts correct quarter", {
                ymd(c("2012-04-30", "2012-04-30", "2012-07-31", "2012-10-31", "2013-01-31")))
 
   x <- ymd("2010-01-01") + months(0:11)
-  expect_equal(quarter(x, type = "quarter_year", fiscal_start = 6),
+  expect_equal(quarter(x, type = "year.quarter", fiscal_start = 6),
                c(2010.3, 2010.3, 2010.4, 2010.4, 2010.4, 2011.1, 2011.1, 2011.1,
                  2011.2, 2011.2, 2011.2, 2011.3))
-  expect_equal(quarter(x, type = "quarter_year", fiscal_start = 6),
-               quarter(x, type = "quarter_year", fiscal_start = -6))
+  expect_equal(quarter(x, type = "year.quarter", fiscal_start = 6),
+               quarter(x, type = "year.quarter", fiscal_start = -6))
   expect_equal(quarter(x, type = "date_first", fiscal_start = 6),
                ymd(c("2009-12-01", "2009-12-01", "2010-03-01", "2010-03-01",
                      "2010-03-01", "2010-06-01", "2010-06-01", "2010-06-01",
@@ -306,10 +309,10 @@ test_that("quarters accessor extracts correct quarter", {
                quarter(x, type = "date_last", fiscal_start = -6))
 
   x <- ymd("2010-01-01") + months(seq(0, 23, by = 3))
-  expect_equal(quarter(x, type = "quarter_year", fiscal_start = 10),
+  expect_equal(quarter(x, type = "year.quarter", fiscal_start = 10),
                c(2010.2, 2010.3, 2010.4, 2011.1, 2011.2, 2011.3, 2011.4, 2012.1))
-  expect_equal(quarter(x, type = "quarter_year", fiscal_start = -2),
-               quarter(x, type = "quarter_year", fiscal_start = 10))
+  expect_equal(quarter(x, type = "year.quarter", fiscal_start = -2),
+               quarter(x, type = "year.quarter", fiscal_start = 10))
   expect_equal(quarter(x, type = "date_first", fiscal_start = 10),
                ymd(c("2010-01-01", "2010-04-01", "2010-07-01", "2010-10-01",
                  "2011-01-01", "2011-04-01", "2011-07-01", "2011-10-01")))
@@ -326,10 +329,12 @@ test_that("quarters accessor extracts correct quarter", {
              "2019-12-31", "2020-01-01", "2020-06-30",
              "2020-07-01", "2020-11-09", "2021-01-19",
              "2021-06-30", "2021-07-01"))
-  expect_equal(quarter(x, type = "quarter_year", fiscal_start = 7),
+  expect_equal(quarter(x, type = "year.quarter", fiscal_start = 7),
                c(2019.1, 2019.2, 2019.3, 2019.4, 2020.1, 2020.2, 2020.2, 2020.3,
                  2020.4, 2021.1, 2021.2, 2021.3, 2021.4, 2022.1))
-  expect_equal(quarter(x, type = "date_first", fiscal_start = 7),
+  out <- quarter(x, type = "date_first", fiscal_start = 7)
+  expect_s3_class(out, "Date")
+  expect_equal(out,
                ymd(c("2018-07-01", "2018-10-01", "2019-01-01", "2019-04-01",
                      "2019-07-01", "2019-10-01", "2019-10-01", "2020-01-01",
                      "2020-04-01", "2020-07-01", "2020-10-01", "2021-01-01",


### PR DESCRIPTION
Addresses https://github.com/tidyverse/lubridate/issues/947. With this, the API now looks like:
```r
quarter(x) # default behaviour is unchanged
quarter(x, type = "quarter_year") # equivalent to what would previously be passing `with_year = TRUE`
quarter(x, type = "date_first") # new functionality
quarter(x, type = "date_last") # new functionality
```
The `with_year` parameter is soft-deprecated, but will continue to work for the time being.