### PR TITLE
Both B and b now call C parser 0b in guess_formats()

### DIFF
--- a/R/guess.r
+++ b/R/guess.r
@@ -87,7 +87,7 @@ guess_formats <- function(x, orders, locale = Sys.getlocale("LC_TIME"),
   if (length(wm <- grepl("(?<!O)m", orders, perl = T)))
     orders <- c(sub("m", "Om", orders[wm]), orders)
   if (length(wm <- grepl("(?<!O)[bB]", orders, perl = T)))
-    orders <- c(sub("b", "Ob", orders[wm]), orders)
+    orders <- c(sub("[Bb]", "Ob", orders[wm]), orders)
   if (length(wT <- grepl("T", orders, fixed = T)))
     orders <- c(sub("T", "HMSOp", orders[wT], fixed = T), orders)
   if (length(wR <- grepl("R", orders, fixed = T)))

--- a/tests/testthat/test-guess.R
+++ b/tests/testthat/test-guess.R
@@ -91,3 +91,29 @@ test_that("guess_format works with missing entries", {
                guess_formats(c("01-01-10", NA), "mdy"))
   expect_null(guess_formats(NA, "mdy"))
 })
+
+test_that("guess_format consistently adds 0b for B and b", {
+  # Abbreviated month names:
+  expect_true("Obdy" %in% names(guess_formats("jan 3 2010", "bdy")))
+  expect_true("Obdy" %in% names(guess_formats("jan 3 2010", "Bdy")))
+  # Full month names:
+  expect_true("Obdy" %in% names(guess_formats("January 5 1999", "Bdy")))
+  expect_true("Obdy" %in% names(guess_formats("January 5 1999", "Bdy")))
+})
+
+test_that("b/B give complete and equivalent results for trained parsing", {
+  full <- c("february  14, 2004", "January 5 1999")
+  mixed <- c("jan 3 2010", "January 5 1999")
+  short <- c("jan 3 2010", "Jan 1, 1999")
+  expect_equal(parse_date_time(full, "bdy"),
+               parse_date_time(full, "Bdy"))
+  expect_equal(parse_date_time(mixed, "bdy"),
+               parse_date_time(mixed, "Bdy"))
+  expect_equal(parse_date_time(short, "bdy"),
+               parse_date_time(short, "Bdy"))
+
+  expect_false(any(is.na(parse_date_time(full, "bdy"))))
+  expect_false(any(is.na(parse_date_time(mixed, "bdy"))))
+  expect_false(any(is.na(parse_date_time(short, "bdy"))))
+})
+


### PR DESCRIPTION
Raising a small issue with `guess_formats()` along with a proposed easy fix.

Documentation of `guess_formats()` indicated that b & B are considered equivalent.  This is true in the actual parser called by `.strptime`, but not in the guessing code.  Previously, this could lead to parsing failure when "B" was used alongside data that only contained abbreviated months.  

A simple change in string substitution in the function appears to correct things issue.  Given the if-statement on the line just above the one edited, I think this is just fixing a typo to match what was already intended.

**Currently:**
``` r
require(lubridate, quietly = TRUE, warn.conflicts = FALSE)

# Data from examples of guess_format():

# A mix of full and abbreviated months:
mixed <- c("jan 3 2010", "January 5 1999")
# Just abbreviations:
abbrev <- c("jan 3 2010", "Jan 1, 1999")


# when using guess_format(), only the 'b' version matches both:
guess_formats(mixed, c("BdY"), print_matches = TRUE)
#>                       BdY        BdY       
#> [1,] "jan 3 2010"     ""         ""        
#> [2,] "January 5 1999" "%B %d %Y" "%B %d %Y"
#>        BdY        BdY 
#> "%B %d %Y" "%B %d %Y"

guess_formats(mixed, c("bdy"), print_matches = TRUE)
#>                       Obdy        bdy       
#> [1,] "jan 3 2010"     "%Ob %d %Y" "%b %d %Y"
#> [2,] "January 5 1999" "%Ob %d %Y" "%B %d %Y"
#>        Obdy        Obdy         bdy         bdy 
#> "%Ob %d %Y" "%Ob %d %Y"  "%b %d %Y"  "%B %d %Y"

# B thus offers no options with only abbreviated months:
guess_formats(abbrev, c("BdY"), print_matches = TRUE)
#>                    BdY BdY
#> [1,] "jan 3 2010"  ""  "" 
#> [2,] "Jan 1, 1999" ""  ""
#> NULL


# When dataset contains a mix of abbreviated & full names, 
# trained parsing works fine with either b or B:

parse_date_time(mixed, "bdy")
#> [1] "2010-01-03 UTC" "1999-01-05 UTC"
parse_date_time(mixed, "Bdy")
#> [1] "2010-01-03 UTC" "1999-01-05 UTC"

# But only b works if it's just abbreviations:

parse_date_time(abbrev, "bdy")
#> [1] "2010-01-03 UTC" "1999-01-01 UTC"
parse_date_time(abbrev, "Bdy")
#> Warning: All formats failed to parse. No formats found.
#> [1] NA NA
```

<sup>Created on 2021-05-15 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

**With proposed change:**
``` r
require(lubridate, quietly = TRUE, warn.conflicts = FALSE)

mixed <- c("jan 3 2010", "January 5 1999")
abbrev <- c("jan 3 2010", "Jan 1, 1999")

# Both approaches now introduce 0b as option:

guess_formats(mixed, c("BdY"), print_matches = TRUE)
#>                       ObdY        BdY       
#> [1,] "jan 3 2010"     "%Ob %d %Y" ""        
#> [2,] "January 5 1999" "%Ob %d %Y" "%B %d %Y"
#>        ObdY        ObdY         BdY 
#> "%Ob %d %Y" "%Ob %d %Y"  "%B %d %Y"

guess_formats(mixed, c("bdY"), print_matches = TRUE)
#>                       ObdY        bdY       
#> [1,] "jan 3 2010"     "%Ob %d %Y" "%b %d %Y"
#> [2,] "January 5 1999" "%Ob %d %Y" "%B %d %Y"
#>        ObdY        ObdY         bdY         bdY 
#> "%Ob %d %Y" "%Ob %d %Y"  "%b %d %Y"  "%B %d %Y"

# And both work now fine with just abbreviations:

parse_date_time(abbrev, "bdy")
#> [1] "2010-01-03 UTC" "1999-01-01 UTC"

parse_date_time(abbrev, "Bdy")
#> [1] "2010-01-03 UTC" "1999-01-01 UTC"
```

<sup>Created on 2021-05-15 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>
