### PR TITLE
`quiet` parameter for `stamp_date` and `stamp_time`

### DIFF
--- a/R/stamp.r
+++ b/R/stamp.r
@@ -196,14 +196,15 @@ stamp <- function(x, orders = lubridate_formats,
 
 ##' @rdname stamp
 ##' @export
-stamp_date <- function(x, locale = Sys.getlocale("LC_TIME"))
+stamp_date <- function(x, locale = Sys.getlocale("LC_TIME"), quiet = FALSE)
   stamp(x, orders = c("ymd", "dmy", "mdy", "ydm", "dym", "myd", "my", "ym", "md", "dm", "m", "d", "y"),
-        locale = locale)
+        locale = locale, quiet = quiet)
 
 ##' @rdname stamp
 ##' @export
-stamp_time <- function(x, locale = Sys.getlocale("LC_TIME"))
-  stamp(x, orders = c("hms", "hm", "ms", "h", "m", "s"), locale = locale)
+stamp_time <- function(x, locale = Sys.getlocale("LC_TIME"), quiet = FALSE)
+  stamp(x, orders = c("hms", "hm", "ms", "h", "m", "s"),
+        locale = locale, quiet = quiet)
 
 
 lubridate_formats <- local({


### PR DESCRIPTION
Pass `quiet` parameter to `stamp`.

So that parameters of `stamp_date` and `stamp_time` are more consistent with `stamp` itself.
(and allow reduction of unwanted 'informative' messages).

example:

```
> dateformat <- lubridate::stamp_date("2021-07-15")
Multiple formats matched: "%Y-%Om-%d"(1), "%Y-%m-%d"(1)
Using: "%Y-%Om-%d"
> dateformat <- lubridate::stamp_date("2021-07-15", quiet = TRUE)
> dateformat
function(x, locale = .(locale)) {
      .(reset_local_expr)
      format(x, format = .(FMT))
    }
<environment: 0x55ab54c3efb0>
> timeformat <- lubridate::stamp_time("4:53 p.m.", quiet = TRUE)
Warning message:
hms, hm and ms usage is deprecated, please use HMS, HM or MS instead. Deprecated in version '1.5.6'. 
> timeformat(Sys.time())
[1] "18:38 p.m."
> timeformat <- lubridate::stamp_time("4:53 p.m.")
Multiple formats matched: "%H:%M p.m."(1), "%M:%S p.m."(1)
Using: "%H:%M p.m."
Warning message:
hms, hm and ms usage is deprecated, please use HMS, HM or MS instead. Deprecated in version '1.5.6'. 
```