### PR TITLE
Disambiguate `<Duration> - <Duration>` and `<Period> - <Period>`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ Version 1.7.10.9000 (dev)
 
 ### BUG FIXES
 
+* [#994](https://github.com/tidyverse/lubridate/issues/994) Subtracting two duration or two period objects no longer results in an ambiguous dispatch note.
+
 * `as_datetime(date, tz=XYZ)` returns the date-time object with HMS set to 00:00:00 in the corresponding `tz`
 
 Version 1.7.10

--- a/R/durations.r
+++ b/R/durations.r
@@ -54,7 +54,7 @@ setClass("Duration", contains = c("Timespan", "numeric"), validity = check_durat
 #'   /,Duration,numeric-method /,numeric,Duration-method *,Duration,ANY-method
 #'   *,ANY,Duration-method %%,Duration,Duration-method
 #'   %%,Duration,Interval-method %%,Duration,Period-method
-#'   -,Duration,missing-method -,ANY,Duration-method
+#'   -,Duration,missing-method -,ANY,Duration-method -,Duration,Duration-method
 NULL
 
 SECONDS_IN_ONE <- c(

--- a/R/ops-subtraction.r
+++ b/R/ops-subtraction.r
@@ -26,12 +26,22 @@ setMethod("-", signature(e1 = "Interval", e2 = "missing"),
 setMethod("-", signature(e1 = "Period", e2 = "missing"),
           function(e1, e2) multiply_period_by_number(e1, -1))
 
+# To disambiguate in the <Duration> - <Duration> case, avoiding a note (#994)
+#' @export
+setMethod("-", signature(e1 = "Duration", e2 = "Duration"),
+          function(e1, e2) e1  + (-e2))
+
 #' @export
 setMethod("-", signature(e1 = "ANY", e2 = "Duration"),
           function(e1, e2) e1  + (-e2))
 
 #' @export
 setMethod("-", signature(e1 = "Duration", e2 = "ANY"),
+          function(e1, e2) e1  + (-e2))
+
+# To disambiguate in the <Period> - <Period> case, avoiding a note (#994)
+#' @export
+setMethod("-", signature(e1 = "Period", e2 = "Period"),
           function(e1, e2) e1  + (-e2))
 
 #' @export

--- a/R/periods.r
+++ b/R/periods.r
@@ -113,28 +113,29 @@ setClass("Period", contains = c("Timespan", "numeric"),
 #'   /,Period,Period-method /,Period,difftime-method /,difftime,Period-method
 #'   /,Period,numeric-method /,numeric,Period-method *,Period,ANY-method
 #'   *,ANY,Period-method -,Period,ANY-method -,Period,missing-method
-#'   -,ANY,Period-method %%,Period,Duration-method %%,Period,Interval-method
-#'   %%,Period,Period-method >,Period,Period-method >=,Period,Period-method
-#'   ==,Period,Period-method !=,Period,Period-method <=,Period,Period-method
-#'   <,Period,Period-method >,Period,Duration-method >=,Period,Duration-method
-#'   ==,Period,Duration-method !=,Period,Duration-method
-#'   <=,Period,Duration-method <,Period,Duration-method >,Duration,Period-method
-#'   >=,Duration,Period-method ==,Duration,Period-method
-#'   !=,Duration,Period-method <=,Duration,Period-method
-#'   <,Duration,Period-method >,Period,numeric-method >=,Period,numeric-method
-#'   ==,Period,numeric-method !=,Period,numeric-method <=,Period,numeric-method
-#'   <,Period,numeric-method >,numeric,Period-method >=,numeric,Period-method
-#'   ==,numeric,Period-method !=,numeric,Period-method <=,numeric,Period-method
-#'   <,numeric,Period-method !=,Duration,Period !=,Period,Duration
-#'   !=,Period,Period !=,Period,numeric !=,numeric,Period %%,Period,Duration
-#'   %%,Period,Interval %%,Period,Period *,ANY,Period *,Period,ANY -,ANY,Period
-#'   -,Period,Interval -,Period,missing /,numeric,Period <,Duration,Period
-#'   <,Period,Duration <,Period,Period <,Period,numeric <,numeric,Period
-#'   <=,Duration,Period <=,Period,Duration <=,Period,Period <=,Period,numeric
-#'   <=,numeric,Period ==,Duration,Period ==,Period,Duration ==,Period,Period
-#'   ==,Period,numeric ==,numeric,Period >,Duration,Period >,Period,Duration
-#'   >,Period,Period >,Period,numeric >,numeric,Period >=,Duration,Period
-#'   >=,Period,Duration >=,Period,Period >=,Period,numeric >=,numeric,Period
+#'   -,ANY,Period-method -,Period,Period-method %%,Period,Duration-method
+#'   %%,Period,Interval-method %%,Period,Period-method >,Period,Period-method
+#'   >=,Period,Period-method ==,Period,Period-method !=,Period,Period-method
+#'   <=,Period,Period-method <,Period,Period-method >,Period,Duration-method
+#'   >=,Period,Duration-method ==,Period,Duration-method
+#'   !=,Period,Duration-method <=,Period,Duration-method
+#'   <,Period,Duration-method >,Duration,Period-method >=,Duration,Period-method
+#'   ==,Duration,Period-method !=,Duration,Period-method
+#'   <=,Duration,Period-method <,Duration,Period-method >,Period,numeric-method
+#'   >=,Period,numeric-method ==,Period,numeric-method !=,Period,numeric-method
+#'   <=,Period,numeric-method <,Period,numeric-method >,numeric,Period-method
+#'   >=,numeric,Period-method ==,numeric,Period-method !=,numeric,Period-method
+#'   <=,numeric,Period-method <,numeric,Period-method !=,Duration,Period
+#'   !=,Period,Duration !=,Period,Period !=,Period,numeric !=,numeric,Period
+#'   %%,Period,Duration %%,Period,Interval %%,Period,Period *,ANY,Period
+#'   *,Period,ANY -,ANY,Period -,Period,Interval -,Period,missing
+#'   /,numeric,Period <,Duration,Period <,Period,Duration <,Period,Period
+#'   <,Period,numeric <,numeric,Period <=,Duration,Period <=,Period,Duration
+#'   <=,Period,Period <=,Period,numeric <=,numeric,Period ==,Duration,Period
+#'   ==,Period,Duration ==,Period,Period ==,Period,numeric ==,numeric,Period
+#'   >,Duration,Period >,Period,Duration >,Period,Period >,Period,numeric
+#'   >,numeric,Period >=,Duration,Period >=,Period,Duration >=,Period,Period
+#'   >=,Period,numeric >=,numeric,Period
 NULL
 
 setMethod("initialize", "Period", function(.Object, ...) {

--- a/man/hidden_aliases.Rd
+++ b/man/hidden_aliases.Rd
@@ -121,6 +121,7 @@
 \alias{\%\%,Duration,Period-method}
 \alias{-,Duration,missing-method}
 \alias{-,ANY,Duration-method}
+\alias{-,Duration,Duration-method}
 \alias{Arith,ANY,Period-method}
 \alias{Arith,Duration,Period-method}
 \alias{Arith,Period,Duration-method}
@@ -184,6 +185,7 @@
 \alias{-,Period,ANY-method}
 \alias{-,Period,missing-method}
 \alias{-,ANY,Period-method}
+\alias{-,Period,Period-method}
 \alias{\%\%,Period,Duration-method}
 \alias{\%\%,Period,Interval-method}
 \alias{\%\%,Period,Period-method}


### PR DESCRIPTION
Closes #994 

This PR adds two `-` S4 methods to disambiguate the case where you subtract two Period or two Duration objects.

This is hard to test because the Note appears once per session, but I've added a comment to try and keep us from accidentally removing this in the future.