### PR TITLE
Re-document package

### DIFF
--- a/R/intervals.r
+++ b/R/intervals.r
@@ -557,7 +557,8 @@ setdiff.Interval <- function(x, y, ...) {
 #' int2 %within% int # TRUE
 #' ymd("1999-01-01") %within% int # FALSE
 #'
-#' ## recycling (carefully note the difference between using a vector of intervals and list of intervals for the second argument)
+#' ## recycling (carefully note the difference between using a vector of
+#' ## intervals and list of intervals for the second argument)
 #' dates <- ymd(c("2014-12-20", "2014-12-30", "2015-01-01", "2015-01-03"))
 #' blackout_vector <- c(interval(ymd("2014-12-30"), ymd("2014-12-31")),
 #'               interval(ymd("2014-12-30"), ymd("2015-01-03")))

--- a/man/duration.Rd
+++ b/man/duration.Rd
@@ -67,7 +67,7 @@ a duration object
 \code{duration()} creates a duration object with the specified values. Entries
 for different units are cumulative. durations display as the number of
 seconds in a time span. When this number is large, durations also display an
-estimate in larger units,; however, the underlying object is always recorded
+estimate in larger units, however, the underlying object is always recorded
 as a fixed number of seconds. For display and creation purposes, units are
 converted to seconds using their most common lengths in seconds. Minutes = 60
 seconds, hours = 3600 seconds, days = 86400 seconds, weeks = 604800. Units
@@ -130,7 +130,7 @@ duration("day 2 sec") > "day 1sec"
 dseconds(1)
 dminutes(3.5)
 
-x <- ymd_hms("2009-08-03", tz="America/Chicago")
+x <- ymd("2009-08-03", tz = "America/Chicago")
 x + ddays(1) + dhours(6) + dminutes(30)
 x + ddays(100) - dhours(8)
 
@@ -143,7 +143,7 @@ dweeks(1) - ddays(7)
 c(1:3) * dhours(1)
 
 # compare DST handling to durations
-boundary <- ymd_hms("2009-03-08 01:59:59", tz="America/Chicago")
+boundary <- ymd_hms("2009-03-08 01:59:59", tz = "America/Chicago")
 boundary + days(1) # period
 boundary + ddays(1) # duration
 is.duration(as.Date("2009-08-03")) # FALSE

--- a/man/round_date.Rd
+++ b/man/round_date.Rd
@@ -35,7 +35,7 @@ to be rounded to. Valid base units are \code{second}, \code{minute}, \code{hour}
 constructor are allowed. Rounding to multiples of units (except weeks) is
 supported.}
 
-\item{week_start}{when unit is \code{weeks}, specify the reference day.
+\item{week_start}{when unit is \code{week}, specify the reference day.
 7 represents Sunday and 1 represents Monday.}
 
 \item{change_on_boundary}{if this is \code{NULL} (the default), instants on the boundary

--- a/man/within-interval.Rd
+++ b/man/within-interval.Rd
@@ -34,7 +34,8 @@ ymd("2001-05-03") \%within\% int # TRUE
 int2 \%within\% int # TRUE
 ymd("1999-01-01") \%within\% int # FALSE
 
-## recycling (carefully note the difference between using a vector of intervals and list of intervals for the second argument)
+## recycling (carefully note the difference between using a vector of
+## intervals and list of intervals for the second argument)
 dates <- ymd(c("2014-12-20", "2014-12-30", "2015-01-01", "2015-01-03"))
 blackout_vector <- c(interval(ymd("2014-12-30"), ymd("2014-12-31")),
               interval(ymd("2014-12-30"), ymd("2015-01-03")))

--- a/man/within-interval.Rd
+++ b/man/within-interval.Rd
@@ -15,7 +15,7 @@ a \%within\% b
 
 \item{b}{Either an interval vector, or a list of intervals.
 
-If \code{b} is an interval it is recycled to the same length as \code{a}.
+If \code{b} is an interval (or interval vector) it is recycled to the same length as \code{a}.
 If \code{b} is a list of intervals, \code{a} is checked if it falls within \emph{any}
 of the intervals, i.e. \code{a \%within\% list(int1, int2)} is equivalent to
 \code{a \%within\% int1 | a \%within\% int2}.}
@@ -34,15 +34,15 @@ ymd("2001-05-03") \%within\% int # TRUE
 int2 \%within\% int # TRUE
 ymd("1999-01-01") \%within\% int # FALSE
 
-## recycling
+## recycling (carefully note the difference between using a vector of intervals and list of intervals for the second argument)
 dates <- ymd(c("2014-12-20", "2014-12-30", "2015-01-01", "2015-01-03"))
-blackouts<- c(interval(ymd("2014-12-30"), ymd("2014-12-31")),
+blackout_vector <- c(interval(ymd("2014-12-30"), ymd("2014-12-31")),
               interval(ymd("2014-12-30"), ymd("2015-01-03")))
-dates \%within\% blackouts
+dates \%within\% blackout_vector
 
 ## within ANY of the intervals of a list
 dates <- ymd(c("2014-12-20", "2014-12-30", "2015-01-01", "2015-01-03"))
-blackouts<- list(interval(ymd("2014-12-30"), ymd("2014-12-31")),
+blackout_list<- list(interval(ymd("2014-12-30"), ymd("2014-12-31")),
                  interval(ymd("2014-12-30"), ymd("2015-01-03")))
-dates \%within\% blackouts
+dates \%within\% blackout_list
 }


### PR DESCRIPTION
It seems like some of the Rd files have gotten out of date, so I just ran `devtools::document()` to update.

Also fixed a CRAN check note about a long line in one of the files that got updated:

```r
> checking Rd line widths ... NOTE
  Rd file 'within-interval.Rd':
    \examples lines wider than 100 characters:
       ## recycling (carefully note the difference between using a vector of intervals and list of intervals for the second argument)
  
  These lines will be truncated in the PDF manual.
```