### PR TITLE
Fix testing changes due to new vctrs outputs

### DIFF
--- a/tests/testthat/output/test-vctrs.txt
+++ b/tests/testthat/output/test-vctrs.txt
@@ -3,102 +3,102 @@ no common type when mixing Period/Duration/Interval
 ===================================================
 
 > vec_ptype2(period(), duration())
-Error: Can't combine <Period> and <Duration>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't combine <Period> and <Duration>.
 
 > vec_ptype2(duration(), period())
-Error: Can't combine <Duration> and <Period>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't combine <Duration> and <Period>.
 
 > vec_ptype2(period(), interval())
-Error: Can't combine <Period> and <Interval>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't combine <Period> and <Interval>.
 
 > vec_ptype2(interval(), period())
-Error: Can't combine <Interval> and <Period>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't combine <Interval> and <Period>.
 
 > vec_ptype2(duration(), interval())
-Error: Can't combine <Duration> and <Interval>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't combine <Duration> and <Interval>.
 
 > vec_ptype2(interval(), duration())
-Error: Can't combine <Interval> and <Duration>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't combine <Interval> and <Duration>.
 
 
 can't cast between Period/Duration/Interval
 ===========================================
 
 > vec_cast(period(), duration())
-Error: Can't convert <Period> to <Duration>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't convert <Period> to <Duration>.
 
 > vec_cast(duration(), period())
-Error: Can't convert <Duration> to <Period>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't convert <Duration> to <Period>.
 
 > vec_cast(period(), interval())
-Error: Can't convert <Period> to <Interval>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't convert <Period> to <Interval>.
 
 > vec_cast(interval(), period())
-Error: Can't convert <Interval> to <Period>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't convert <Interval> to <Period>.
 
 > vec_cast(duration(), interval())
-Error: Can't convert <Duration> to <Interval>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't convert <Duration> to <Interval>.
 
 > vec_cast(interval(), duration())
-Error: Can't convert <Interval> to <Duration>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't convert <Interval> to <Duration>.
 
 
 Period default ptype2 method falls through to `vec_default_ptype2()`
 ====================================================================
 
 > vec_ptype2(period(), 1)
-Error: Can't combine <Period> and <double>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't combine <Period> and <double>.
 
 > vec_ptype2(1, period())
-Error: Can't combine <double> and <Period>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't combine <double> and <Period>.
 
 
 Period default cast method falls through to `vec_default_cast()`
 ================================================================
 
 > vec_cast(period(), 1)
-Error: Can't convert <Period> to <double>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't convert <Period> to <double>.
 
 > vec_cast(1, period())
-Error: Can't convert <double> to <Period>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't convert <double> to <Period>.
 
 
 Duration default ptype2 method falls through to `vec_default_ptype2()`
 ======================================================================
 
 > vec_ptype2(duration(), 1)
-Error: Can't combine <Duration> and <double>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't combine <Duration> and <double>.
 
 > vec_ptype2(1, duration())
-Error: Can't combine <double> and <Duration>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't combine <double> and <Duration>.
 
 
 Duration default cast method falls through to `vec_default_cast()`
 ==================================================================
 
 > vec_cast(duration(), 1)
-Error: Can't convert <Duration> to <double>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't convert <Duration> to <double>.
 
 > vec_cast(1, duration())
-Error: Can't convert <double> to <Duration>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't convert <double> to <Duration>.
 
 
 Interval default ptype2 method falls through to `vec_default_ptype2()`
 ======================================================================
 
 > vec_ptype2(interval(), 1)
-Error: Can't combine <Interval> and <double>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't combine <Interval> and <double>.
 
 > vec_ptype2(1, interval())
-Error: Can't combine <double> and <Interval>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't combine <double> and <Interval>.
 
 
 Interval default cast method falls through to `vec_default_cast()`
 ==================================================================
 
 > vec_cast(interval(), 1)
-Error: Can't convert <Interval> to <double>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't convert <Interval> to <double>.
 
 > vec_cast(1, interval())
-Error: Can't convert <double> to <Interval>.
+Error in stop_vctrs(message, class = c(class, "vctrs_error_incompatible"), : Can't convert <double> to <Interval>.
 


### PR DESCRIPTION
An unrelated testing error popped up with committing #1022.  The error is due to format changes in the vctrs error messages.  This updates those tests.

There is another test (unrelated to #1022 as well) that is failing on my local system.  I'm not sure what the correct resolution is to that, so I will raise an issue for it.