### PR TITLE
Possible improvements to 'wday.numeric'

### DIFF
--- a/R/accessors-day.r
+++ b/R/accessors-day.r
@@ -21,6 +21,7 @@ NULL
 #'   the first level of the returned factor. You can set `lubridate.week.start`
 #'   option to control this parameter globally.
 #' @param locale locale to use for day names. Default to current locale.
+#' @param ... optional arguments passed to methods.
 #' @return `wday()` returns the day of the week as a decimal number or an
 #'   ordered factor if label is `TRUE`.
 #' @keywords utilities manip chron methods
@@ -51,13 +52,13 @@ mday <- day
 #' @export
 wday <- function(x, label = FALSE, abbr = TRUE,
                  week_start = getOption("lubridate.week.start", 7),
-                 locale = Sys.getlocale("LC_TIME"))
+                 locale = Sys.getlocale("LC_TIME"), ...)
   UseMethod("wday")
 
 #' @export
 wday.default <- function(x, label = FALSE, abbr = TRUE,
                          week_start = getOption("lubridate.week.start", 7),
-                         locale = Sys.getlocale("LC_TIME")) {
+                         locale = Sys.getlocale("LC_TIME"), ...) {
   wday(as.POSIXlt(x, tz = tz(x))$wday + 1, label, abbr, locale = locale, week_start = week_start)
 }
 
@@ -72,24 +73,25 @@ wday.default <- function(x, label = FALSE, abbr = TRUE,
 #' @export
 wday.numeric <- function(x, label = FALSE, abbr = TRUE,
                          week_start = getOption("lubridate.week.start", 7),
-                         locale = Sys.getlocale("LC_TIME")) {
-
-  start <- as.integer(week_start)
-
-  if (start > 7 || start < 1)
-    stop("Invalid 'week_start' argument; must be between 1 and 7")
-
-  if (start != 7) {
-    x <- 1 + (x + (6 - start)) %% 7
+                         locale = Sys.getlocale("LC_TIME"),
+                         week_start_x = 7, ...) {
+  to <- as.integer(week_start)
+  if (to > 7L || to < 1L) {
+    stop("'week_start' must be a number from 1 to 7")
   }
-
+  from <- as.integer(week_start_x)
+  if (from > 7L || from < 1L) {
+    stop("'week_start_x' must be a number from 1 to 7")
+  }
+  if (to != from) {
+    x <- 1L + (x - (to - from + 1L)) %% 7L
+  }
   if (!label) {
     return(x)
   }
-
   names <- .get_locale_regs(locale)$wday_names
   labels <- if (abbr) names$abr else names$full
-  ordered(x, levels = 1:7, labels = .shift_wday_names(labels, week_start = start))
+  ordered(x, levels = 1:7, labels = .shift_wday_names(labels, week_start = to))
 }
 
 #' @export

--- a/R/accessors-day.r
+++ b/R/accessors-day.r
@@ -84,16 +84,14 @@ wday.numeric <- function(x, label = FALSE, abbr = TRUE,
   if (to > 7L || to < 1L) {
     stop("'week_start' must be a number from 1 to 7")
   }
-  if (from != to) {
-    x <- 1L + (x - (to - from + 1L)) %% 7L
-  }
+  x <- 1L + (x - (to - from + 1L)) %% 7L
   if (!label) {
     return(x)
   }
   names <- .get_locale_regs(locale)$wday_names
   names <- if (abbr) names$abr else names$full
   labels <- .shift_wday_names(names, week_start = to)
-  ordered(x, levels = 1:7, labels = labels)
+  gl(7L, 1L, labels = labels, ordered = TRUE)[x]
 }
 }
 
@@ -111,16 +109,14 @@ wday.numeric <- function(x, label = FALSE, abbr = TRUE,
   if (to > 7L || to < 1L) {
     stop("'to_sunday' must be a number from 1 to 7")
   }
-  if (to != from) {
-    x <- 1L + (x + (to - from - 1L)) %% 7L
-  }
+  x <- 1L + (x + (to - from - 1L)) %% 7L
   if (!label) {
     return(x)
   }
   names <- .get_locale_regs(locale)$wday_names
   names <- if (abbr) names$abr else names$full
   labels <- .shift_wday_names(names, week_start = 8L - to)
-  ordered(x, levels = 1:7, labels = labels)
+  gl(7L, 1L, labels = labels, ordered = TRUE)[x]
 }
 
 #' @export

--- a/R/accessors-day.r
+++ b/R/accessors-day.r
@@ -70,28 +70,57 @@ wday.default <- function(x, label = FALSE, abbr = TRUE,
   }
 }
 
-#' @export
+## Option 1:
+if (FALSE) {
 wday.numeric <- function(x, label = FALSE, abbr = TRUE,
                          week_start = getOption("lubridate.week.start", 7),
                          locale = Sys.getlocale("LC_TIME"),
                          week_start_x = 7, ...) {
-  to <- as.integer(week_start)
-  if (to > 7L || to < 1L) {
-    stop("'week_start' must be a number from 1 to 7")
-  }
   from <- as.integer(week_start_x)
   if (from > 7L || from < 1L) {
     stop("'week_start_x' must be a number from 1 to 7")
   }
-  if (to != from) {
+  to <- as.integer(week_start)
+  if (to > 7L || to < 1L) {
+    stop("'week_start' must be a number from 1 to 7")
+  }
+  if (from != to) {
     x <- 1L + (x - (to - from + 1L)) %% 7L
   }
   if (!label) {
     return(x)
   }
   names <- .get_locale_regs(locale)$wday_names
-  labels <- if (abbr) names$abr else names$full
-  ordered(x, levels = 1:7, labels = .shift_wday_names(labels, week_start = to))
+  names <- if (abbr) names$abr else names$full
+  labels <- .shift_wday_names(names, week_start = to)
+  ordered(x, levels = 1:7, labels = labels)
+}
+}
+
+## Option 2
+#' @export
+wday.numeric <- function(x, label = FALSE, abbr = TRUE,
+                         week_start = getOption("lubridate.week.start", 7),
+                         locale = Sys.getlocale("LC_TIME"),
+                         from_sunday = 1, to_sunday = 8 - week_start, ...) {
+  from <- as.integer(from_sunday)
+  if (from > 7L || from < 1L) {
+    stop("'from_sunday' must be a number from 1 to 7")
+  }
+  to <- as.integer(to_sunday)
+  if (to > 7L || to < 1L) {
+    stop("'to_sunday' must be a number from 1 to 7")
+  }
+  if (to != from) {
+    x <- 1L + (x + (to - from - 1L)) %% 7L
+  }
+  if (!label) {
+    return(x)
+  }
+  names <- .get_locale_regs(locale)$wday_names
+  names <- if (abbr) names$abr else names$full
+  labels <- .shift_wday_names(names, week_start = 8L - to)
+  ordered(x, levels = 1:7, labels = labels)
 }
 
 #' @export

--- a/man/day.Rd
+++ b/man/day.Rd
@@ -22,7 +22,8 @@ wday(
   label = FALSE,
   abbr = TRUE,
   week_start = getOption("lubridate.week.start", 7),
-  locale = Sys.getlocale("LC_TIME")
+  locale = Sys.getlocale("LC_TIME"),
+  ...
 )
 
 qday(x)
@@ -58,6 +59,8 @@ the first level of the returned factor. You can set \code{lubridate.week.start}
 option to control this parameter globally.}
 
 \item{locale}{locale to use for day names. Default to current locale.}
+
+\item{...}{optional arguments passed to methods.}
 
 \item{value}{a numeric object}
 }


### PR DESCRIPTION
Re: #1025 

`wday.numeric` gains an optional argument `week_start_x` indicating the coding of argument `x`. The default value is 7, meaning 1=Sunday, for backwards compatibility. Hence anyone doing `wday(<numeric>)` without specifying `week_start_x` should see the same behaviour as before.

Some tests, which could easily go into `test-accessors.R` ...

```r
library("lubridate")

wday(1:7, week_start_x = 7, week_start = 7) # from 1=Sunday to 1=Sunday (no-op)
## [1] 1 2 3 4 5 6 7

wday(1:7, week_start_x = 1, week_start = 7) # from 1=Monday to 1=Sunday
## [1] 2 3 4 5 6 7 1

wday(1:7, week_start_x = 7, week_start = 1) # from 1=Sunday to 1=Monday
## [1] 7 1 2 3 4 5 6
```