### PR TITLE
Recycle the `isdst` field in `.mklt()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ Version 1.8.0.9000
 
 ### BUG FIXES
 
+* [#1044](https://github.com/tidyverse/lubridate/issues/1044) POSIXlt results returned by `fast_strptime()` and `parse_date_time2()` now have a recycled `isdst` field.
 * Fix rounding of POSIXlt objects
 * [#1007](https://github.com/tidyverse/lubridate/issues/1007) Internal lubridate formats are no longer propagated to stamp formater.
 * `train` argument in `parse_date_time` now takes effect. It was previously ignored.

--- a/R/parse.r
+++ b/R/parse.r
@@ -761,10 +761,15 @@ fast_strptime <- function(x, format, tz = "UTC", lt = TRUE, cutoff_2000 = 68L) {
 
 ### INTERNAL
 .mklt <- function(dtlist, tz) {
-  na_fill <- rep_len(NA_integer_, length(dtlist$sec))
+  n <- length(dtlist$sec)
+
+  na_fill <- rep_len(NA_integer_, n)
   dtlist[["wday"]] <- na_fill
   dtlist[["yday"]] <- na_fill
-  dtlist[["isdst"]] <- -1L
+
+  dst_fill <- rep_len(-1L, n)
+  dtlist[["isdst"]] <- dst_fill
+
   .POSIXlt(dtlist, tz = tz)
 }
 

--- a/tests/testthat/test-parsers.R
+++ b/tests/testthat/test-parsers.R
@@ -974,6 +974,17 @@ test_that("parse_date_time2 and fast_strptime correctly return lt objects", {
   expect_s3_class(fast_strptime("12/03/16 12:00", "%d/%m/%y %H:%M", lt = FALSE), "POSIXct")
 })
 
+test_that("lt objects returned by parse_date_time2 and fast_strptime recycle the `isdst` field", {
+  ## https://github.com/tidyverse/lubridate/issues/1044
+  x <- c("12/03/16 12:00", "12/03/16 14:00")
+
+  out <- parse_date_time2(x, "dmy HM", lt = TRUE)
+  expect_identical(unclass(out)[["isdst"]], c(-1L, -1L))
+
+  out <- fast_strptime(x, "%d/%m/%y %H:%M")
+  expect_identical(unclass(out)[["isdst"]], c(-1L, -1L))
+})
+
 test_that("ymd_hms, parse_date_time2, fast_strptime and base:strptime give the same result", {
   ## random times between 1400 and 3000
   set.seed(1000)


### PR DESCRIPTION
Closes #1044 