### PR TITLE
Fix R-devel CRAN checks: use format(), not as.character() for time/date

### DIFF
--- a/R/coercion.r
+++ b/R/coercion.r
@@ -600,6 +600,9 @@ setMethod("as.numeric", signature(x = "Period"), function(x, units = "second", .
 
 as.POSIXt <- function(x) as.POSIXlt(x)
 
+## TODO{MM}:  Do not confuse  as.character()  and  format()
+## -------   {originally were used interchangably in R for Date and POSIX?t}
+
 #' @export
 setMethod("as.character", signature(x = "Period"), function(x, ...) {
   format(x)

--- a/R/format_ISO8601.r
+++ b/R/format_ISO8601.r
@@ -28,7 +28,7 @@ setMethod("format_ISO8601",
   function(x, usetz = FALSE, precision = NULL, ...) {
     precision_format <-
       format_ISO8601_precision_check(precision = precision, max_precision = "ymd", usetz = FALSE)
-    as.character(x, format = precision_format, usetz = FALSE)
+    format(x, format = precision_format, usetz = FALSE)
   }
 )
 

--- a/R/format_ISO8601.r
+++ b/R/format_ISO8601.r
@@ -39,7 +39,7 @@ setMethod("format_ISO8601",
     precision_format <-
       format_ISO8601_precision_check(precision = precision, max_precision = "ymdhms", usetz = usetz)
     # Note that the usetz argument to as.character is always FALSE because the time zone is handled in the precision argument.
-    as.character(x, format = precision_format, usetz = FALSE)
+    format(x, format = precision_format, usetz = FALSE)
   }
 )
 
@@ -52,8 +52,8 @@ setMethod("format_ISO8601",
     # Note that the usetz argument to as.character is always FALSE because the time zone is handled in the precision argument.
     sprintf(
       "%s/%s",
-      as.character(x@start, format = precision_format, usetz = FALSE),
-      as.character(x@start + x@.Data, format = precision_format, usetz = FALSE)
+      format(x@start,           format = precision_format, usetz = FALSE),
+      format(x@start + x@.Data, format = precision_format, usetz = FALSE)
     )
   }
 )


### PR DESCRIPTION
Use  format()  not as.character()   for  POSIX[cl]t  and Date   --- will pass CRAN checks with R-devel