### PR TITLE
Recycle all POSIXlt fields when doing period month/year addition

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ Version 1.8.0.9000
 
 ### BUG FIXES
 
+* [#1069](https://github.com/tidyverse/lubridate/issues/1069) Internal code handling the addition of period months and years no longer generates partially recycled POSIXlt objects.
 * Fix rounding of POSIXlt objects
 * [#1007](https://github.com/tidyverse/lubridate/issues/1007) Internal lubridate formats are no longer propagated to stamp formater.
 * `train` argument in `parse_date_time` now takes effect. It was previously ignored.

--- a/R/ops-addition.r
+++ b/R/ops-addition.r
@@ -89,8 +89,9 @@ add_months <- function(mt, mos) {
   }
 
   if (anyNA(new_mon)) {
-    # Ensure missing value assignment propagates to all fields
-    mt[is.na(new_mon)] <- NA
+    # Ensure missing value assignment propagates to all fields.
+    # Can't just assign `NA` https://stat.ethz.ch/pipermail/r-devel/2022-October/082080.html.
+    mt[is.na(new_mon)] <- as.POSIXlt(NA, tz = tz(mt))
   }
 
   mt$mon <- new_mon
@@ -99,8 +100,9 @@ add_months <- function(mt, mos) {
   invalid <- mt$mday != ndays
 
   if (any(invalid, na.rm = TRUE)) {
-    # Ensure missing value assignment propagates to all fields
-    mt[invalid] <- NA
+    # Ensure missing value assignment propagates to all fields.
+    # Can't just assign `NA` https://stat.ethz.ch/pipermail/r-devel/2022-October/082080.html.
+    mt[invalid] <- as.POSIXlt(NA, tz = tz(mt))
   }
 
   mt

--- a/R/ops-addition.r
+++ b/R/ops-addition.r
@@ -77,9 +77,32 @@ add_months <- function(mt, mos) {
   if (all(mos[nnas] == 0L)) {
     return(mt)
   }
-  mt$mon <- mt$mon + mos
+
+  new_mon <- mt$mon + mos
+  new_length <- length(new_mon)
+
+  # "recycle" all fields of `mt` as needed according to base R rules.
+  # Partial recycling warning will be thrown on the `+` above.
+  # TODO: This should use tidyverse recycling rules (#1070).
+  if (new_length != length(mt$mon)) {
+    mt <- rep(mt, length.out = new_length)
+  }
+
+  if (anyNA(new_mon)) {
+    # Ensure missing value assignment propagates to all fields
+    mt[is.na(new_mon)] <- NA
+  }
+
+  mt$mon <- new_mon
+
   ndays <- as.numeric(format.POSIXlt(mt, "%d", usetz = FALSE))
-  mt$mon[mt$mday != ndays] <- NA
+  invalid <- mt$mday != ndays
+
+  if (any(invalid, na.rm = TRUE)) {
+    # Ensure missing value assignment propagates to all fields
+    mt[invalid] <- NA
+  }
+
   mt
 }
 

--- a/tests/testthat/test-ops-addition.R
+++ b/tests/testthat/test-ops-addition.R
@@ -324,14 +324,14 @@ test_that("addition with period months and years returns NA when appropriate", {
   expect_equal(leap - years(0:4), yrs2)
 
   # Again with Dates (#1069)
-  jan <- as.Date(jan)
-  feb <- as.Date(feb)
-  mar <- as.Date(mar)
-  leap <- as.Date(leap)
-  mos <- as.Date(mos)
-  yrs <- as.Date(yrs)
-  mos2 <- as.Date(mos2)
-  yrs2 <- as.Date(yrs2)
+  jan <- as_date(jan)
+  feb <- as_date(feb)
+  mar <- as_date(mar)
+  leap <- as_date(leap)
+  mos <- as_date(mos)
+  yrs <- as_date(yrs)
+  mos2 <- as_date(mos2)
+  yrs2 <- as_date(yrs2)
 
   expect_equal(jan + months(0:11), mos)
   expect_equal(feb + months(1), mar)
@@ -343,18 +343,18 @@ test_that("addition with period months and years returns NA when appropriate", {
 })
 
 test_that("addition with period months recycles correctly", {
-  x <- as.Date(c("2019-01-01", "2019-01-02"))
-  y <- as.POSIXct(x, tz = "UTC")
+  x <- as_date(c("2019-01-01", "2019-01-02"))
+  y <- as_datetime(x, tz = "UTC")
 
   period <- months(1)
-  x_expect <- as.Date(c("2019-02-01", "2019-02-02"))
-  y_expect <- as.POSIXct(x_expect, tz = "UTC")
+  x_expect <- as_date(c("2019-02-01", "2019-02-02"))
+  y_expect <- as_datetime(x_expect, tz = "UTC")
   expect_identical(x + period, x_expect)
   expect_identical(y + period, y_expect)
 
   period <- months(NA_integer_)
-  x_expect <- as.Date(c(NA, NA))
-  y_expect <- as.POSIXct(x_expect, tz = "UTC")
+  x_expect <- as_date(c(NA, NA))
+  y_expect <- as_datetime(x_expect, tz = "UTC")
   expect_identical(x + period, x_expect)
   expect_identical(y + period, y_expect)
 
@@ -367,15 +367,15 @@ test_that("addition with period months recycles correctly", {
 
   # TODO: Should be an error, see #1070
   period <- months(1:3)
-  x_expect <- as.Date(c("2019-02-01", "2019-03-02", "2019-04-01"))
-  y_expect <- as.POSIXct(x_expect, tz = "UTC")
+  x_expect <- as_date(c("2019-02-01", "2019-03-02", "2019-04-01"))
+  y_expect <- as_datetime(x_expect, tz = "UTC")
   expect_warning(expect_identical(x + period, x_expect))
   expect_warning(expect_identical(y + period, y_expect))
 
   # TODO: Should be an error, see #1070
   period <- months(c(1, 2, NA))
-  x_expect <- as.Date(c("2019-02-01", "2019-03-02", NA))
-  y_expect <- as.POSIXct(x_expect, tz = "UTC")
+  x_expect <- as_date(c("2019-02-01", "2019-03-02", NA))
+  y_expect <- as_datetime(x_expect, tz = "UTC")
   expect_warning(expect_identical(x + period, x_expect))
   expect_warning(expect_identical(y + period, y_expect))
 })


### PR DESCRIPTION
Part of https://github.com/tidyverse/lubridate/issues/1069, specifically my comment in https://github.com/tidyverse/lubridate/issues/1069#issuecomment-1268892740

So now we get this in the current state of R-devel again

``` r
as.Date("2019-01-30") + months(0:3)
#> [1] "2019-01-30" NA           "2019-03-30" "2019-04-30"
```

I've checked that this fixes slider too.

I'm convinced that this was an R-devel bug and I've sent them a message here about it https://stat.ethz.ch/pipermail/r-devel/2022-October/082066.html. Nevertheless, I feel like we could be more robust about recycling the fields of the POSIXlt objects where possible to avoid these issues altogether. Relying on base R's hidden recycling of the POSIXlt fields seems dangerous, and I'm not sure it is really documented well.

We also actually use base R recycling rules (accidentally?) here due to the `+` call. I've opened https://github.com/tidyverse/lubridate/issues/1070 to track a move towards tidyverse recycling rules, but for now I have tried to keep the base R recycling rules intact.

This patch doesn't actually fix the `floor_date()` issue in #1069. But it is possible the fixing of the r-devel bug itself will fix that issue. I am not sure yet, but will look at that in another PR. It probably implies we are partially recycling POSIXlt objects somewhere else, so it would be good to track it down either way.