### PR TITLE
Place names on the `.Data` column of the proxy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Suggests:
     knitr,
     rmarkdown,
     testthat (>= 2.1.0),
-    vctrs (>= 0.4.1)
+    vctrs (>= 0.5.0)
 Enhances:
     chron,
     data.table,

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ Version 1.8.0.9000
 
 ### BUG FIXES
 
+* [#1072](https://github.com/tidyverse/lubridate/issues/1072) Names are now handled correctly when combining multiple Period or Interval objects.
 * [#1003](https://github.com/tidyverse/lubridate/issues/1003) Correctly handle r and R formats in locales which have no p format
 * [#1074](https://github.com/tidyverse/lubridate/issues/1074) Fix concatination of named Period, Interval and Duration vectors.
 * [#1044](https://github.com/tidyverse/lubridate/issues/1044) POSIXlt results returned by `fast_strptime()` and `parse_date_time2()` now have a recycled `isdst` field.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,15 +5,11 @@
 
   on_package_load("vctrs", {
     register_s3_method("vctrs", "vec_proxy", "Period")
-    register_s3_method("vctrs", "vec_proxy_compare", "Period")
-    register_s3_method("vctrs", "vec_proxy_equal", "Period")
     register_s3_method("vctrs", "vec_restore", "Period")
     register_s3_method("vctrs", "vec_ptype2", "Period.Period")
     register_s3_method("vctrs", "vec_cast", "Period.Period")
 
     register_s3_method("vctrs", "vec_proxy", "Duration")
-    register_s3_method("vctrs", "vec_proxy_compare", "Duration")
-    register_s3_method("vctrs", "vec_proxy_equal", "Duration")
     register_s3_method("vctrs", "vec_restore", "Duration")
     register_s3_method("vctrs", "vec_ptype2", "Duration.Duration")
     register_s3_method("vctrs", "vec_ptype2", "Duration.difftime")
@@ -23,8 +19,6 @@
     register_s3_method("vctrs", "vec_cast", "difftime.Duration")
 
     register_s3_method("vctrs", "vec_proxy", "Interval")
-    register_s3_method("vctrs", "vec_proxy_compare", "Interval")
-    register_s3_method("vctrs", "vec_proxy_equal", "Interval")
     register_s3_method("vctrs", "vec_restore", "Interval")
     register_s3_method("vctrs", "vec_ptype2", "Interval.Interval")
     register_s3_method("vctrs", "vec_cast", "Interval.Interval")

--- a/tests/testthat/test-vctrs.R
+++ b/tests/testthat/test-vctrs.R
@@ -143,6 +143,13 @@ test_that("can combine Period objects", {
   expect_identical(vec_c(days(1), days(2)), days(1:2))
 })
 
+test_that("can combine Period objects when some are named (#1072)", {
+  skip_if_cant_set_s4_names()
+  x <- days(1)
+  y <- stats::setNames(days(2), "y")
+  expect_named(vec_c(x, y), c("", "y"))
+})
+
 test_that("can row bind Period objects", {
   skip_if_cant_set_s4_names()
   x <- stats::setNames(days(1), "x")
@@ -283,6 +290,13 @@ test_that("slicing preserves names", {
 
 test_that("can combine Duration objects", {
   expect_identical(vec_c(ddays(1), ddays(2)), ddays(1:2))
+})
+
+test_that("can combine Duration objects when some are named (#1072)", {
+  skip_if_cant_set_s4_names()
+  x <- ddays(1)
+  y <- stats::setNames(ddays(2), "y")
+  expect_named(vec_c(x, y), c("", "y"))
 })
 
 test_that("can row bind Duration objects", {
@@ -469,6 +483,13 @@ test_that("can combine Interval objects", {
   y <- interval("1970-01-02")
   expect <- interval(c("1970-01-01", "1970-01-02"))
   expect_identical(vec_c(x, y), expect)
+})
+
+test_that("can combine Interval objects when some are named (#1072)", {
+  skip_if_cant_set_s4_names()
+  x <- interval("1970-01-01")
+  y <- stats::setNames(interval("1970-01-02"), "y")
+  expect_named(vec_c(x, y), c("", "y"))
 })
 
 test_that("can row bind Interval objects", {

--- a/tests/testthat/test-vctrs.R
+++ b/tests/testthat/test-vctrs.R
@@ -45,24 +45,23 @@ test_that("proxy is a data frame", {
   expect_identical(vec_proxy(x), expect)
 })
 
-test_that("proxy can optionally store vector names in the last column (allowing duplicates)", {
+test_that("proxy stores names on the `$second` column (allowing duplicates)", {
   skip_if_cant_set_s4_names()
 
   x <- stats::setNames(days(1:3), c("x", "y", "x"))
 
   proxy <- vec_proxy(x)
 
-  expect_identical(proxy$rcrd_names, names(x))
-  expect_identical(match("rcrd_names", names(proxy)), ncol(proxy))
+  expect_named(proxy$second, names(x))
 })
 
-test_that("comparison / equality proxies don't have the names column", {
+test_that("comparison / equality proxies have the names too", {
   skip_if_cant_set_s4_names()
 
   x <- stats::setNames(days(1:3), c("x", "y", "x"))
 
-  expect_null(vec_proxy_compare(x)$rcrd_names)
-  expect_null(vec_proxy_equal(x)$rcrd_names)
+  expect_named(vec_proxy_compare(x)$second, names(x))
+  expect_named(vec_proxy_equal(x)$second, names(x))
 })
 
 test_that("restore method works", {
@@ -190,11 +189,11 @@ test_that("proxy stores the names", {
   expect_named(vec_proxy(x), c("x", "y", "x"))
 })
 
-test_that("comparison / equality proxies don't store names", {
+test_that("comparison / equality proxies store names too", {
   skip_if_cant_set_s4_names()
   x <- stats::setNames(ddays(1:3), c("x", "y", "x"))
-  expect_named(vec_proxy_compare(x), NULL)
-  expect_named(vec_proxy_equal(x), NULL)
+  expect_named(vec_proxy_compare(x), names(x))
+  expect_named(vec_proxy_equal(x), names(x))
 })
 
 test_that("restore method works", {
@@ -326,7 +325,7 @@ test_that("proxy is a data frame", {
   expect_identical(vec_proxy(x), expect)
 })
 
-test_that("proxy can optionally store vector names in the last column (allowing duplicates)", {
+test_that("proxy stores names on the `$span` column (allowing duplicates)", {
   skip_if_cant_set_s4_names()
 
   x <- c("2019-01-01", "2019-01-02", "2019-01-03")
@@ -334,18 +333,17 @@ test_that("proxy can optionally store vector names in the last column (allowing 
 
   proxy <- vec_proxy(x)
 
-  expect_identical(proxy$rcrd_names, names(x))
-  expect_identical(match("rcrd_names", names(proxy)), ncol(proxy))
+  expect_named(proxy$span, names(x))
 })
 
-test_that("comparison / equality proxies don't have the names column", {
+test_that("comparison / equality proxies have the names too", {
   skip_if_cant_set_s4_names()
 
   x <- c("2019-01-01", "2019-01-02", "2019-01-03")
   x <- stats::setNames(interval(x), c("x", "y", "x"))
 
-  expect_null(vec_proxy_compare(x)$rcrd_names)
-  expect_null(vec_proxy_equal(x)$rcrd_names)
+  expect_named(vec_proxy_compare(x)$span, names(x))
+  expect_named(vec_proxy_equal(x)$span, names(x))
 })
 
 test_that("restore method works", {


### PR DESCRIPTION
Closes #1072 

We now store the names on the column that corresponds to the `@.Data` slot of the original object. For Period this is `$second` and for Interval this is `$span`. This fixes the problem of #1072 because it means that we never have a mismatch in the number of columns that are on the proxy.

A few extra niceties here:
- No need for compare/equal proxy methods anymore, we just carry around the names unconditionally, which doesn't hurt anything
- No need for the complicated recursive proxying done in the Interval methods, because in vctrs 0.5.0 if a data frame is returned as the proxy then it will automatically proxy the columns recursively too (CC @lionel- this is a nice side effect of that change we made)