### PR TITLE
Improve examples in `wday()`

### DIFF
--- a/R/accessors-day.r
+++ b/R/accessors-day.r
@@ -29,6 +29,7 @@ NULL
 #' @examples
 #' x <- as.Date("2009-09-02")
 #' wday(x) # 4
+#' wday(x, label = TRUE) # Wed (Wednesday)
 #'
 #' wday(ymd(080101))
 #' wday(ymd(080101), label = TRUE, abbr = FALSE)

--- a/R/accessors-day.r
+++ b/R/accessors-day.r
@@ -31,6 +31,9 @@ NULL
 #' wday(x) # 4
 #' wday(x, label = TRUE) # Wed (Wednesday)
 #'
+#' wday(x, week_start = 1) # 3
+#' wday(x, week_start = 7) # 4
+#'
 #' wday(ymd(080101))
 #' wday(ymd(080101), label = TRUE, abbr = FALSE)
 #' wday(ymd(080101), label = TRUE, abbr = TRUE)


### PR DESCRIPTION
A better illustration of the relationship between weekday name in words and weekday number as well as between weekday number and the value of argument `week_start`. 
Related to #1100 