### PR TITLE
Use explicit integers in `year()` and `month()`

### DIFF
--- a/R/accessors-month.r
+++ b/R/accessors-month.r
@@ -35,7 +35,7 @@ month <- function(x, label = FALSE, abbr = TRUE, locale = Sys.getlocale("LC_TIME
 
 #' @export
 month.default <- function(x, label = FALSE, abbr = TRUE, locale = Sys.getlocale("LC_TIME")) {
-  month(as.POSIXlt(x, tz = tz(x))$mon + 1, label, abbr, locale = locale)
+  month(as.POSIXlt(x, tz = tz(x))$mon + 1L, label, abbr, locale = locale)
 }
 
 #' @export

--- a/R/accessors-year.r
+++ b/R/accessors-year.r
@@ -26,7 +26,7 @@ year <- function(x) {
 
 #' @export
 year.default <- function(x) {
-  as.POSIXlt(x, tz = tz(x))$year + 1900
+  as.POSIXlt(x, tz = tz(x))$year + 1900L
 }
 
 #' @export


### PR DESCRIPTION
An astute student pointed out to use that `day()`, `year()` and `month()` are inconsistent in their return types:

``` r
library(lubridate)
x <- ymd("2012-03-26")
is.integer(month(x))
#> [1] FALSE
is.integer(day(x))
#> [1] TRUE
is.integer(year(x))
#> [1] FALSE
```

<sup>Created on 2022-12-15 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

This seems like an unintentional conversion due to addition. This PR uses explicit integer addition to have `month()` and `year()` return integers