### PR TITLE
Fix `@year` slot recycling in `as.period(unit = "month")`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 Version 1.9.2.9000
 ==================
 
+### BUG FIXES
+
+* [#1109](https://github.com/tidyverse/lubridate/issues/1109) Fix recycling of the year slot in `as.period(unit = "month")` with Periods and Intervals.
 
 Version 1.9.2
 =============

--- a/R/coercion.r
+++ b/R/coercion.r
@@ -407,10 +407,8 @@ setMethod("as.period", signature(x = "Interval"), function(x, unit = NULL, ...) 
   switch(unit,
     year = .int_to_period(x),
     month = {
-      pers <- .int_to_period(x)
-      month(pers) <- month(pers) + year(pers) * 12
-      year(pers) <- 0
-      pers
+      x <- .int_to_period(x)
+      as.period(x, unit = unit)
     },
     ## fixme: add note to the docs that unit <= days results in much faster conversion
     ## fixme: add week
@@ -544,9 +542,17 @@ setMethod(
       switch(unit,
         year = x,
         month = {
-          month(x) <- month(x) + year(x) * 12
-          year(x) <- 0
-          x
+          years <- 0
+          months <- month(x) + year(x) * 12
+          new(
+            "Period",
+            x$second,
+            year = years,
+            month = months,
+            day = x$day,
+            hour = x$hour,
+            minute = x$minute
+          )
         },
         day = ,
         hour = ,

--- a/tests/testthat/test-periods.R
+++ b/tests/testthat/test-periods.R
@@ -304,6 +304,31 @@ test_that("as.period with different units handles interval objects", {
   expect_equal(as.period(int, "second") + start, end)
 })
 
+test_that("as.period on intervals with months unit recycles and standardizes the new 0 year (#1109)", {
+  start <- ymd("2019-01-01") + c(0, NA, 2)
+  end <- ymd("2023-01-02") + c(0, NA, 100)
+  int <- interval(start, end, tzone = "UTC")
+
+  x <- as.period(int, "months")
+
+  expect_identical(x, months(c(48, NA, 51)) + days(c(1, NA, 9)))
+
+  # In particular, the year slot should be recycled and have `NA`s standardized
+  expect_identical(x@year, c(0, NA, 0))
+  expect_identical(year(x), c(0, NA, 0))
+})
+
+test_that("as.period on periods with months unit recycles and standardizes the new 0 year (#1109)", {
+  x <- years(c(1, NA, 2))
+  x <- as.period(x, "months")
+
+  expect_identical(x, months(c(12, NA, 24)))
+
+  # In particular, the year slot should be recycled and have `NA`s standardized
+  expect_identical(x@year, c(0, NA, 0))
+  expect_identical(year(x), c(0, NA, 0))
+})
+
 test_that("period constructor works num-unit args", {
   expect_equal(period(1, c("sec", "hour")), period("1H 1S"))
   expect_equal(period(1:3, c("sec", "hour", "min")), period("2H 1S 3M"))


### PR DESCRIPTION
Closes #1109 