### PR TITLE
docs: use period() in period's examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 SystemRequirements: C++11, A system with zoneinfo data (e.g.
     /usr/share/zoneinfo). On Windows the zoneinfo included with R is used.
 Collate:

--- a/R/periods.r
+++ b/R/periods.r
@@ -390,7 +390,7 @@ setMethod("$<-", signature(x = "Period"), function(x, name, value) {
 #' period("2days 2hours 2mins 2secs")
 #' period("2 days, 2 hours, 2 mins, 2 secs")
 #' # Missing numerals default to 1. Repeated units are added up.
-#' duration("day day")
+#' period("day day")
 #'
 #' ### ISO 8601 parsing
 #'
@@ -401,7 +401,7 @@ setMethod("$<-", signature(x = "Period"), function(x, name, value) {
 #'
 #' ### Comparison with characters (from v1.6.0)
 #'
-#' duration("day 2 sec") > "day 1sec"
+#' period("day 2 sec") > "day 1sec"
 #'
 #' ### Elementary Constructors
 #'

--- a/man/period.Rd
+++ b/man/period.Rd
@@ -126,7 +126,7 @@ period("2d 2H 2M 2S")
 period("2days 2hours 2mins 2secs")
 period("2 days, 2 hours, 2 mins, 2 secs")
 # Missing numerals default to 1. Repeated units are added up.
-duration("day day")
+period("day day")
 
 ### ISO 8601 parsing
 
@@ -137,7 +137,7 @@ period("P23DT60H 20min 100 sec") # mixing ISO and lubridate style parsing
 
 ### Comparison with characters (from v1.6.0)
 
-duration("day 2 sec") > "day 1sec"
+period("day 2 sec") > "day 1sec"
 
 ### Elementary Constructors
 


### PR DESCRIPTION
Given the context, `period()` seems appropriate, not `duration()`.