### PR TITLE
Use CONDA_PREFIX for timezone database if available

### DIFF
--- a/R/tzdir.R
+++ b/R/tzdir.R
@@ -29,21 +29,29 @@ tzdir_get <- function() {
 
 ## adapted from Syz.timezone and OlsonNames function
 tzdir_find <- function() {
-  if (.Platform$OS.type == "windows") {
-    return(tzdir_internal())
+  tzdirs <- c()
+
+  conda_prefix <- Sys.getenv("CONDA_PREFIX")
+  if (conda_prefix != "") {
+    tzdirs <- c(tzdirs, file.path(conda_prefix, "share", "zoneinfo"))
   }
 
-  tzdirs <- c(
-    "/usr/share/zoneinfo",
-    "/usr/share/lib/zoneinfo",
-    "/usr/lib/zoneinfo",
-    "/usr/local/etc/zoneinfo",
-    "/etc/zoneinfo",
-    "/usr/etc/zoneinfo",
-    "/usr/share/zoneinfo.default",
-    "/var/db/timezone/zoneinfo",
-    tzdir_internal()
-  )
+  if (.Platform$OS.type != "windows") {
+    tzdirs <- c(
+      tzdirs,
+      "/usr/share/zoneinfo",
+      "/usr/share/lib/zoneinfo",
+      "/usr/lib/zoneinfo",
+      "/usr/local/etc/zoneinfo",
+      "/etc/zoneinfo",
+      "/usr/etc/zoneinfo",
+      "/usr/share/zoneinfo.default",
+      "/var/db/timezone/zoneinfo"
+    )
+  }
+
+  tzdirs <- c(tzdirs, tzdir_internal())
+
   tzdirs <- tzdirs[file.exists(tzdirs)]
   if (length(tzdirs)) {
     tzdirs[[1]]


### PR DESCRIPTION
As discussed in #1117, this allows lubridate to use the timezone database in a conda environment if R is currently being executed in one. The conda environment is detected and located using the `CONDA_PREFIX` environment variable.

The behavior of lubridate was tested before and after this change. Indeed, the timezone information that is installed by the standard `tzdata` conda package at `${CONDA_PREFIX}/share/zoneinfo` is detected and used.

Please check the logic around the handling of Windows. Because conda environment can exist on Windows (and are actually a very nice way to set up a scientific programming environment there), I reorganized the way `tzdir_find` works to avoid too much nesting.