### PR TITLE
timechange dependency is 0.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Depends:
     R (>= 3.2)
 Imports:
     generics,
-    timechange (>= 0.1.1)
+    timechange (>= 0.2.0)
 Suggests:
     covr,
     knitr,


### PR DESCRIPTION
Alternatively, since the newer version is really only required in tests, we can `skip_if_not_installed("timechange, "0.2.0")` here:

https://github.com/tidyverse/lubridate/blob/e54b612c0672c57bb9cea12dd2482b0d59b3aa64/tests/testthat/test-round.R#L655