### PR TITLE
Implement `leap_year()` in C

### DIFF
--- a/R/leap-years.r
+++ b/R/leap-years.r
@@ -21,5 +21,5 @@ leap_year <- function(date) {
   } else {
     year <- year(date)
   }
-  (year %% 4 == 0) & ((year %% 100 != 0) | (year %% 400 == 0))
+  .Call(C_is_leap_year, as.integer(year))
 }

--- a/src/init.c
+++ b/src/init.c
@@ -8,12 +8,14 @@ extern SEXP C_make_d(SEXP, SEXP, SEXP);
 extern SEXP C_parse_dt(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP C_parse_hms(SEXP, SEXP);
 extern SEXP C_parse_period(SEXP);
+extern SEXP C_is_leap_year(SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
   {"C_make_d",              (DL_FUNC) &C_make_d,              3},
   {"C_parse_dt",            (DL_FUNC) &C_parse_dt,            5},
   {"C_parse_hms",           (DL_FUNC) &C_parse_hms,           2},
   {"C_parse_period",        (DL_FUNC) &C_parse_period,        1},
+  {"C_is_leap_year",        (DL_FUNC) &C_is_leap_year,        1},
   {NULL, NULL, 0}
 };
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -27,6 +27,27 @@
 #include <ctype.h>
 #include <Rinternals.h>
 
+SEXP C_is_leap_year(SEXP year) {
+  if(!isInteger(year)) error("year must be integer");
+
+  R_len_t n = LENGTH(year);
+  int* pyear = INTEGER(year);
+
+  SEXP res = allocVector(LGLSXP, n);
+  int *data = LOGICAL(res);
+
+  for(int i = 0; i < n; i++) {
+    int y = pyear[i];
+    if(y == NA_INTEGER) {
+      data[i] = NA_LOGICAL;
+    } else {
+      data[i] = IS_LEAP(y);
+    }
+  }
+
+  return res;
+}
+
 // return adjustment (in seconds) due to leap years
 // y: years after (positive) or before (negative) 2000-01-01 00:00:00
 int adjust_leap_years(int y, int m, int is_leap){

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -6,6 +6,10 @@ test_that("leap_year correctly identifies leap years", {
   expect_true(leap_year(y))
 })
 
+test_that("leap_year handles missing values", {
+  expect_equal(leap_year(NA), NA)
+})
+
 test_that("leap_year handles various date-time vectors", {
   x <- as.POSIXct(c("2008-08-03 12:01:59", "2009-08-03 12:01:59"), tz = "UTC")
 


### PR DESCRIPTION
I noticed the [fastymd](https://cran.r-project.org/package=fastymd) package hitting CRAN recently. One of its features is fast leap year calculations, which made me wonder how lubridate stacks up.

Currently `leap_year()` is pure R and is relatively speaking quite slow. With the lubridate main branch:

``` r
library(microbenchmark)

set.seed(42)
years <- sample(4000, 1e4, replace = TRUE)

microbenchmark(
  fastymd::is_leap(years),
  lubridate::leap_year(years),
  times = 1e4
)
#> Unit: microseconds
#>                         expr   min    lq       mean median     uq      max neval cld
#>      fastymd::is_leap(years)  29.4  47.8   65.64309   52.6   64.2  11538.7 10000  a 
#>  lubridate::leap_year(years) 792.3 986.5 1203.30433 1020.2 1139.0 298644.7 10000   b
```

<sup>Created on 2025-05-01 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

This PR moves the leap year calculation to C, simply wrapping the `IS_LEAP` macro already used elsewhere in the codebase. With it I see a roughly 30-fold performance increase on my machine:

``` r
library(microbenchmark)

set.seed(42)
years <- sample(4000, 1e4, replace = TRUE)

microbenchmark(
  fastymd::is_leap(years),
  lubridate::leap_year(years),
  times = 1e4
)
#> Unit: microseconds
#>                         expr  min   lq     mean median   uq    max neval cld
#>      fastymd::is_leap(years) 29.2 44.1 64.90436   48.4 55.8  20797 10000   a
#>  lubridate::leap_year(years) 15.6 30.4 72.39227   34.6 40.2 310873 10000   a
```

<sup>Created on 2025-05-01 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>



