### PR TITLE
fix: skip French locale test when locale unavailable (#1213)

### DIFF
--- a/tests/testthat/test-parsers.R
+++ b/tests/testthat/test-parsers.R
@@ -1121,6 +1121,8 @@ test_that("parser ignores case", {
 test_that("parsing months with dots works in French linux locale", {
   skip_on_cran()
   skip_on_os(c("mac", "solaris", "windows"))
+  suppressWarnings(testthat::skip_if(Sys.setlocale("LC_TIME", "fr_FR.utf8") == ""))
+  on.exit(Sys.setlocale("LC_TIME", "C"))
   expect_equal(
     parse_date_time("02 janv. 2015 12:48", "dbYHM", locale = "fr_FR.utf8"),
     ymd_hms("2015-01-02 12:48:00 UTC")


### PR DESCRIPTION
## Problem

Test "parsing months with dots works in French linux locale" (`test-parsers.R:1121`) errors on systems where `fr_FR.utf8` is not installed:

```
Error in `Sys.setlocale("LC_TIME", locale)`: (converted from warning) OS reports request to set locale to "fr_FR.utf8" cannot be honored
```

## Fix

Added `skip_if` guard and `on.exit` cleanup, matching the existing pattern in the adjacent test "parsing with r and R formats works in non-english locale" (line 1143):

```r
suppressWarnings(testthat::skip_if(Sys.setlocale("LC_TIME", "fr_FR.utf8") == ""))
on.exit(Sys.setlocale("LC_TIME", "C"))
```

## Testing

- Ran `testthat::test_file("tests/testthat/test-parsers.R")` — all tests pass
- On macOS: test skipped via `skip_on_os("mac")` (pre-existing)
- On Linux without French locale: now gracefully skipped via `skip_if` (the fix)

Closes #1213